### PR TITLE
Fix velocity calculation in C++ version.

### DIFF
--- a/pathplannerlib/src/main/native/cpp/pathplanner/lib/PathPlannerTrajectory.cpp
+++ b/pathplannerlib/src/main/native/cpp/pathplanner/lib/PathPlannerTrajectory.cpp
@@ -192,7 +192,7 @@ void PathPlannerTrajectory::calculateMaxVel(std::vector<PathPlannerTrajectory::P
         }else{
             states[i].curveRadius = radius;
 
-            units::meters_per_second_t maxVCurve = units::math::sqrt(maxAccel * radius);
+            units::meters_per_second_t maxVCurve = units::math::sqrt(maxAccel * units::math::abs(radius));
 
             states[i].velocity = units::math::min(maxVCurve, states[i].velocity);
         }


### PR DESCRIPTION
When I changed the calculation of curvature to make it be both positive and negative based on the direction the robot is turning, I missed an absolute value on the computation of the maximum curvature velocity in the C++ version (though I got it correct on the Java version, and it got translated correctly into the Dart version). This adds the missing absolute value so that the velocity correctly slows down around sharper turns.