### PR TITLE
Add rotationLerp for interpolation of rotation

### DIFF
--- a/lib/services/generator/geometry_util.dart
+++ b/lib/services/generator/geometry_util.dart
@@ -1,10 +1,24 @@
 import 'dart:math';
 
+import 'package:pathplanner/services/generator/math_util.dart';
 import 'package:flutter/widgets.dart';
 
 class GeometryUtil {
   static num numLerp(num startVal, num endVal, num t) {
     return startVal + (endVal - startVal) * t;
+  }
+
+  static num rotationLerp(num startVal, num endVal, num t, num limit) {
+    if((startVal - endVal).abs() > limit) {
+      if(startVal < 0) {
+        startVal += 2 * limit;
+      } else {
+        endVal += 2 * limit;
+      }
+    }
+    num lerp = startVal + (endVal - startVal) * t;
+    lerp = MathUtil.inputModulus(lerp, -limit, limit);
+    return lerp;
   }
 
   static Point pointLerp(Point startVal, Point endVal, num t) {

--- a/lib/services/generator/trajectory.dart
+++ b/lib/services/generator/trajectory.dart
@@ -355,13 +355,13 @@ class TrajectoryState {
     lerpedState.translationMeters = GeometryUtil.pointLerp(
         this.translationMeters, endVal.translationMeters, t);
     lerpedState.headingRadians =
-        GeometryUtil.numLerp(this.headingRadians, endVal.headingRadians, t);
+        GeometryUtil.rotationLerp(this.headingRadians, endVal.headingRadians, t, pi);
     lerpedState.curvatureRadPerMeter = GeometryUtil.numLerp(
         this.curvatureRadPerMeter, endVal.curvatureRadPerMeter, t);
     lerpedState.angularVelocity =
         GeometryUtil.numLerp(this.angularVelocity, endVal.angularVelocity, t);
-    lerpedState.holonomicRotation = GeometryUtil.numLerp(
-        this.holonomicRotation, endVal.holonomicRotation, t);
+    lerpedState.holonomicRotation = GeometryUtil.rotationLerp(
+        this.holonomicRotation, endVal.holonomicRotation, t, 180);
     lerpedState.holonomicAngularVelocity = GeometryUtil.numLerp(
         this.holonomicAngularVelocity, endVal.holonomicAngularVelocity, t);
     lerpedState.curveRadius =


### PR DESCRIPTION
The Dart implementation of Trajectory uses a linear interpolation for rotation, which does not respect the rotational symmetry. This replaces the linear interpolation of rotation with a rotational interpolation (equivalent to what happens in the C++ and Java version).

This is the reason that the robot in the GUI (on the Preview editor) sometimes "twitches" when it crosses the +/- 180 degree boundary, which no longer happens now.