### PR TITLE
Save paths in human-readable format.

### DIFF
--- a/lib/robot_path/robot_path.dart
+++ b/lib/robot_path/robot_path.dart
@@ -83,7 +83,8 @@ class RobotPath {
   void savePath(Directory saveDir, bool generateJSON, bool generateCSV) async {
     Stopwatch s = Stopwatch()..start();
     File pathFile = File(join(saveDir.path, name + '.path'));
-    pathFile.writeAsString(jsonEncode(this));
+    const JsonEncoder encoder = JsonEncoder.withIndent('  ');
+    pathFile.writeAsString(encoder.convert(this));
 
     this.generatedTrajectory = await Trajectory.generateFullTrajectory(this);
 


### PR DESCRIPTION
Using a human-readable format for the JSON path output has two advantages:

1. It makes it much easier for a version control system to track and highlight what has changed in a path.
2. It makes it easier to hand-edit the path (for precise control-point locations...if you're a bit AR like myself).