### PR TITLE
Update README.md 

### DIFF
--- a/README.md
+++ b/README.md
@@ -28,5 +28,8 @@ Make sure you [install PathPlannerLib](https://github.com/mjansen4857/pathplanne
       * windows
       * macos
       * linux
-* The built app will be located in `<PROJECT DIR>/build/<PLATFORM>/runner/Release`
+* The built app will be located here:
+    * Windows: `<PROJECT DIR>/build/windows/runner/Release`
+    * maxOS: `<PROJECT DIR>/build/macos/Build/Products/Release`
+    * Linux: `<PROJECT DIR>/build/linux/x64/release/bundle`
 * OR `flutter run` to run in debug mode

--- a/README.md
+++ b/README.md
@@ -28,5 +28,5 @@ Make sure you [install PathPlannerLib](https://github.com/mjansen4857/pathplanne
       * windows
       * macos
       * linux
-* The built app will be located in `<PROJECT DIR>/build/<PLATFORM>`
+* The built app will be located in `<PROJECT DIR>/build/<PLATFORM>/runner/Release`
 * OR `flutter run` to run in debug mode


### PR DESCRIPTION
When I build from scratch for windows the .exe file ends up two folders deeper than what is shown in the README.md file. It is located in <Project Folder>\build\windows\runner\Release 
Could just be how Flutter has been setup on my PC.