### PR TITLE
Use list of points instead of vararg for specifying on the fly trajectories.

### DIFF
--- a/pathplannerlib/src/main/java/com/pathplanner/lib/PathPlanner.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/PathPlanner.java
@@ -8,6 +8,8 @@ import edu.wpi.first.wpilibj.Filesystem;
 import java.io.*;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.List;
+
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -237,37 +239,34 @@ public class PathPlanner {
    *
    * @param constraints The max velocity and max acceleration of the path
    * @param reversed Should the robot follow this path reversed
-   * @param point1 First point in the path
-   * @param point2 Second point in the path
-   * @param points Remaining points in the path
+   * @param points Points in the path
    * @return The generated path
    */
   public static PathPlannerTrajectory generatePath(
       PathConstraints constraints,
       boolean reversed,
-      PathPoint point1,
-      PathPoint point2,
-      PathPoint... points) {
-    ArrayList<PathPoint> allPoints = new ArrayList<>();
-    allPoints.add(point1);
-    allPoints.add(point2);
-    allPoints.addAll(Arrays.asList(points));
+      List<PathPoint> points) {
+    if(points.size() < 2) {
+      throw new IllegalArgumentException("Error generating trajectory.  List of points in trajectory must have at least two points.");
+    }
+
+    PathPoint firstPoint = points.get(0);
 
     ArrayList<Waypoint> waypoints = new ArrayList<>();
     waypoints.add(
         new Waypoint(
-            point1.position,
+            firstPoint.position,
             null,
             null,
-            point1.velocityOverride,
-            point1.holonomicRotation,
+            firstPoint.velocityOverride,
+            firstPoint.holonomicRotation,
             false,
             false,
             new PathPlannerTrajectory.StopEvent()));
 
-    for (int i = 1; i < allPoints.size(); i++) {
-      PathPoint p1 = allPoints.get(i - 1);
-      PathPoint p2 = allPoints.get(i);
+    for (int i = 1; i < points.size(); i++) {
+      PathPoint p1 = points.get(i - 1);
+      PathPoint p2 = points.get(i);
 
       double thirdDistance = p1.position.getDistance(p2.position) / 3.0;
 
@@ -308,19 +307,15 @@ public class PathPlanner {
    * @param maxVel The max velocity of the path
    * @param maxAccel The max acceleration of the path
    * @param reversed Should the robot follow this path reversed
-   * @param point1 First point in the path
-   * @param point2 Second point in the path
-   * @param points Remaining points in the path
+   * @param points Points in the path
    * @return The generated path
    */
   public static PathPlannerTrajectory generatePath(
       double maxVel,
       double maxAccel,
       boolean reversed,
-      PathPoint point1,
-      PathPoint point2,
-      PathPoint... points) {
-    return generatePath(new PathConstraints(maxVel, maxAccel), reversed, point1, point2, points);
+      List<PathPoint> points) {
+    return generatePath(new PathConstraints(maxVel, maxAccel), reversed, points);
   }
 
   /**
@@ -330,14 +325,12 @@ public class PathPlanner {
    * close together can lead to really janky paths.
    *
    * @param constraints The max velocity and max acceleration of the path
-   * @param point1 First point in the path
-   * @param point2 Second point in the path
-   * @param points Remaining points in the path
+   * @param points Points in the path
    * @return The generated path
    */
   public static PathPlannerTrajectory generatePath(
-      PathConstraints constraints, PathPoint point1, PathPoint point2, PathPoint... points) {
-    return generatePath(constraints, false, point1, point2, points);
+      PathConstraints constraints, List<PathPoint> points) {
+    return generatePath(constraints, false, points);
   }
 
   /**
@@ -348,14 +341,12 @@ public class PathPlanner {
    *
    * @param maxVel The max velocity of the path
    * @param maxAccel The max acceleration of the path
-   * @param point1 First point in the path
-   * @param point2 Second point in the path
-   * @param points Remaining points in the path
+   * @param points Points in the path
    * @return The generated path
    */
   public static PathPlannerTrajectory generatePath(
-      double maxVel, double maxAccel, PathPoint point1, PathPoint point2, PathPoint... points) {
-    return generatePath(new PathConstraints(maxVel, maxAccel), false, point1, point2, points);
+      double maxVel, double maxAccel, List<PathPoint> points) {
+    return generatePath(new PathConstraints(maxVel, maxAccel), false, points);
   }
 
   /**

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/PathPlanner.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/PathPlanner.java
@@ -307,7 +307,10 @@ public class PathPlanner {
    * @param reversed Should the robot follow this path reversed
    * @param points Points in the path
    * @return The generated path
+   * @deprecated For removal in 2024, use {@link PathPlanner#generatePath(PathConstraints, boolean,
+   *     List)} instead
    */
+  @Deprecated
   public static PathPlannerTrajectory generatePath(
       double maxVel, double maxAccel, boolean reversed, List<PathPoint> points) {
     return generatePath(new PathConstraints(maxVel, maxAccel), reversed, points);
@@ -338,7 +341,10 @@ public class PathPlanner {
    * @param maxAccel The max acceleration of the path
    * @param points Points in the path
    * @return The generated path
+   * @deprecated For removal in 2024, use {@link PathPlanner#generatePath(PathConstraints, List)}
+   *     instead
    */
+  @Deprecated
   public static PathPlannerTrajectory generatePath(
       double maxVel, double maxAccel, List<PathPoint> points) {
     return generatePath(new PathConstraints(maxVel, maxAccel), false, points);
@@ -399,7 +405,10 @@ public class PathPlanner {
    * @param point2 Second point in the path
    * @param points Remaining points in the path
    * @return The generated path
+   * @deprecated For removal in 2024, use {@link PathPlanner#generatePath(PathConstraints,
+   *     PathPoint, PathPoint, PathPoint...)} instead.
    */
+  @Deprecated
   public static PathPlannerTrajectory generatePath(
       double maxVel, double maxAccel, PathPoint point1, PathPoint point2, PathPoint... points) {
     return generatePath(new PathConstraints(maxVel, maxAccel), point1, point2, points);

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/PathPlanner.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/PathPlanner.java
@@ -9,7 +9,6 @@ import java.io.*;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-
 import org.json.simple.JSONArray;
 import org.json.simple.JSONObject;
 import org.json.simple.parser.JSONParser;
@@ -243,11 +242,10 @@ public class PathPlanner {
    * @return The generated path
    */
   public static PathPlannerTrajectory generatePath(
-      PathConstraints constraints,
-      boolean reversed,
-      List<PathPoint> points) {
-    if(points.size() < 2) {
-      throw new IllegalArgumentException("Error generating trajectory.  List of points in trajectory must have at least two points.");
+      PathConstraints constraints, boolean reversed, List<PathPoint> points) {
+    if (points.size() < 2) {
+      throw new IllegalArgumentException(
+          "Error generating trajectory.  List of points in trajectory must have at least two points.");
     }
 
     PathPoint firstPoint = points.get(0);
@@ -311,10 +309,7 @@ public class PathPlanner {
    * @return The generated path
    */
   public static PathPlannerTrajectory generatePath(
-      double maxVel,
-      double maxAccel,
-      boolean reversed,
-      List<PathPoint> points) {
+      double maxVel, double maxAccel, boolean reversed, List<PathPoint> points) {
     return generatePath(new PathConstraints(maxVel, maxAccel), reversed, points);
   }
 

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/PathPlanner.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/PathPlanner.java
@@ -345,6 +345,67 @@ public class PathPlanner {
   }
 
   /**
+   * Generate a path on-the-fly from a list of points As you can't see the path in the GUI when
+   * using this method, make sure you have a good idea of what works well and what doesn't before
+   * you use this method in competition. Points positioned in weird configurations such as being too
+   * close together can lead to really janky paths.
+   *
+   * @param constraints The max velocity and max acceleration of the path
+   * @param reversed Should the robot follow this path reversed
+   * @param point1 First point in the path
+   * @param point2 Second point in the path
+   * @param points Remaining points in the path
+   * @return The generated path
+   */
+  public static PathPlannerTrajectory generatePath(
+      PathConstraints constraints,
+      boolean reversed,
+      PathPoint point1,
+      PathPoint point2,
+      PathPoint... points) {
+    ArrayList<PathPoint> pointsList = new ArrayList<>();
+    pointsList.add(point1);
+    pointsList.add(point2);
+    pointsList.addAll(List.of(points));
+    return generatePath(constraints, reversed, pointsList);
+  }
+
+  /**
+   * Generate a path on-the-fly from a list of points As you can't see the path in the GUI when
+   * using this method, make sure you have a good idea of what works well and what doesn't before
+   * you use this method in competition. Points positioned in weird configurations such as being too
+   * close together can lead to really janky paths.
+   *
+   * @param constraints The max velocity and max acceleration of the path
+   * @param point1 First point in the path
+   * @param point2 Second point in the path
+   * @param points Remaining points in the path
+   * @return The generated path
+   */
+  public static PathPlannerTrajectory generatePath(
+      PathConstraints constraints, PathPoint point1, PathPoint point2, PathPoint... points) {
+    return generatePath(constraints, false, point1, point2, points);
+  }
+
+  /**
+   * Generate a path on-the-fly from a list of points As you can't see the path in the GUI when
+   * using this method, make sure you have a good idea of what works well and what doesn't before
+   * you use this method in competition. Points positioned in weird configurations such as being too
+   * close together can lead to really janky paths.
+   *
+   * @param maxVel The max velocity of the path
+   * @param maxAccel The max acceleration of the path
+   * @param point1 First point in the path
+   * @param point2 Second point in the path
+   * @param points Remaining points in the path
+   * @return The generated path
+   */
+  public static PathPlannerTrajectory generatePath(
+      double maxVel, double maxAccel, PathPoint point1, PathPoint point2, PathPoint... points) {
+    return generatePath(new PathConstraints(maxVel, maxAccel), point1, point2, points);
+  }
+
+  /**
    * Load path constraints from a path file in storage. This can be used to change path max
    * vel/accel in the GUI instead of updating and rebuilding code. This requires that max velocity
    * and max acceleration have been explicitly set in the GUI.

--- a/pathplannerlib/src/main/native/cpp/pathplanner/lib/PathPlanner.cpp
+++ b/pathplannerlib/src/main/native/cpp/pathplanner/lib/PathPlanner.cpp
@@ -1,7 +1,4 @@
 #include "pathplanner/lib/PathPlanner.h"
-#include "pathplanner/lib/PathConstraints.h"
-#include "pathplanner/lib/PathPlannerTrajectory.h"
-#include "pathplanner/lib/PathPoint.h"
 #include <frc/geometry/Translation2d.h>
 #include <frc/geometry/Rotation2d.h>
 #include <frc/Filesystem.h>
@@ -11,8 +8,6 @@
 #include <wpi/raw_istream.h>
 #include <units/length.h>
 #include <units/angle.h>
-#include <units/velocity.h>
-#include <vector>
 
 using namespace pathplanner;
 

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/PathPlanner.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/PathPlanner.h
@@ -92,11 +92,13 @@ public:
 	 * of what works well and what doesn't before you use this method in competition. Points positioned in weird
 	 * configurations such as being too close together can lead to really janky paths.
 	 *
-	 * @param constraints The max velocity and max acceleration of the path
+	 * @param maxVel The max velocity of the path
+	 * @param maxAccel The max acceleration of the path
 	 * @param reversed Should the robot follow this path reversed
 	 * @param points Points in the path
 	 * @return The generated path
 	 */
+	[[deprecated("Use generatePath(PathConstraints, bool, std::vector<PathPoint>) instead")]]
 	static PathPlannerTrajectory generatePath(
 			units::meters_per_second_t const maxVel,
 			units::meters_per_second_squared_t const maxAccel,
@@ -104,7 +106,6 @@ public:
 		return generatePath(PathConstraints { maxVel, maxAccel }, reversed,
 				points);
 	}
-	;
 
 	/**
 	 * @brief Generate a path on-the-fly from a list of points
@@ -128,8 +129,8 @@ public:
 	 * of what works well and what doesn't before you use this method in competition. Points positioned in weird
 	 * configurations such as being too close together can lead to really janky paths.
 	 *
-	 * @param constraints The max velocity and max acceleration of the path
-	 * @param reversed Should the robot follow this path reversed
+	 * @param maxVel The max velocity of the path
+	 * @param maxAccel The max acceleration of the path
 	 * @param points Points in the path
 	 * @return The generated path
 	 */

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/PathPlanner.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/PathPlanner.h
@@ -133,7 +133,7 @@ public:
 	 * @param points Points in the path
 	 * @return The generated path
 	 */
-	 [[deprecated("Use generatePath(PathConstraints, std::vector<PathPoint>) instead")]]
+	[[deprecated("Use generatePath(PathConstraints, std::vector<PathPoint>) instead")]]
 	static PathPlannerTrajectory generatePath(
 			units::meters_per_second_t const maxVel,
 			units::meters_per_second_squared_t const maxAccel,

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/PathPlanner.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/PathPlanner.h
@@ -133,6 +133,7 @@ public:
 	 * @param points Points in the path
 	 * @return The generated path
 	 */
+	 [[deprecated("Use generatePath(PathConstraints, std::vector<PathPoint>) instead")]]
 	static PathPlannerTrajectory generatePath(
 			units::meters_per_second_t const maxVel,
 			units::meters_per_second_squared_t const maxAccel,
@@ -171,6 +172,7 @@ public:
 	 * @param points Remaining points in the path
 	 * @return The generated path
 	 */
+	[[deprecated("Use generatePath(PathConstraints, bool, PathPoint, PathPoint, std::initalizer_list<PathPoint>) instead.")]]
 	static PathPlannerTrajectory generatePath(
 			units::meters_per_second_t const maxVel,
 			units::meters_per_second_squared_t const maxAccel,
@@ -211,6 +213,7 @@ public:
 	 * @param points Remaining points in the path
 	 * @return The generated path
 	 */
+	[[deprecated("Use generatePath(PathConstraints, PathPoint, PathPoint, std::initializer_list<PathPoint>) instead.")]]
 	static PathPlannerTrajectory generatePath(
 			units::meters_per_second_t const maxVel,
 			units::meters_per_second_squared_t const maxAccel,

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/PathPlanner.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/PathPlanner.h
@@ -80,6 +80,74 @@ public:
 	 *
 	 * @param constraints The max velocity and max acceleration of the path
 	 * @param reversed Should the robot follow this path reversed
+	 * @param points Points in the path
+	 * @return The generated path
+	 */
+	static PathPlannerTrajectory generatePath(PathConstraints const constraints,
+			bool const reversed, std::vector<PathPoint> const points);
+
+	/**
+	 * @brief Generate a path on-the-fly from a list of points
+	 * As you can't see the path in the GUI when using this method, make sure you have a good idea
+	 * of what works well and what doesn't before you use this method in competition. Points positioned in weird
+	 * configurations such as being too close together can lead to really janky paths.
+	 *
+	 * @param constraints The max velocity and max acceleration of the path
+	 * @param reversed Should the robot follow this path reversed
+	 * @param points Points in the path
+	 * @return The generated path
+	 */
+	static PathPlannerTrajectory generatePath(
+			units::meters_per_second_t const maxVel,
+			units::meters_per_second_squared_t const maxAccel,
+			bool const reversed, std::vector<PathPoint> const points) {
+		return generatePath(PathConstraints { maxVel, maxAccel }, reversed,
+				points);
+	}
+	;
+
+	/**
+	 * @brief Generate a path on-the-fly from a list of points
+	 * As you can't see the path in the GUI when using this method, make sure you have a good idea
+	 * of what works well and what doesn't before you use this method in competition. Points positioned in weird
+	 * configurations such as being too close together can lead to really janky paths.
+	 *
+	 * @param constraints The max velocity and max acceleration of the path
+	 * @param reversed Should the robot follow this path reversed
+	 * @param points Points in the path
+	 * @return The generated path
+	 */
+	static PathPlannerTrajectory generatePath(PathConstraints const constraints,
+			std::vector<PathPoint> const points) {
+		return generatePath(constraints, false, points);
+	}
+
+	/**
+	 * @brief Generate a path on-the-fly from a list of points
+	 * As you can't see the path in the GUI when using this method, make sure you have a good idea
+	 * of what works well and what doesn't before you use this method in competition. Points positioned in weird
+	 * configurations such as being too close together can lead to really janky paths.
+	 *
+	 * @param constraints The max velocity and max acceleration of the path
+	 * @param reversed Should the robot follow this path reversed
+	 * @param points Points in the path
+	 * @return The generated path
+	 */
+	static PathPlannerTrajectory generatePath(
+			units::meters_per_second_t const maxVel,
+			units::meters_per_second_squared_t const maxAccel,
+			std::vector<PathPoint> const points) {
+		return generatePath(PathConstraints { maxVel, maxAccel }, points);
+	}
+
+	/**
+	 * @brief Generate a path on-the-fly from a list of points
+	 * As you can't see the path in the GUI when using this method, make sure you have a good idea
+	 * of what works well and what doesn't before you use this method in competition. Points positioned in weird
+	 * configurations such as being too close together can lead to really janky paths.
+	 *
+	 * @param constraints The max velocity and max acceleration of the path
+	 * @param reversed Should the robot follow this path reversed
 	 * @param point1 First point in the path
 	 * @param point2 Second point in the path
 	 * @param points Remaining points in the path


### PR DESCRIPTION
This PR changes the generatePath method to accept a list of PathPoints instead of taking two arguments and a vararg of PathPoints.

The reasoning behind this change is situations like my own, where I would like to be able to pass several points into a function to get a command that runs a path.  Using the PathPlanner generatePath method everywhere would mean unnecessary code duplication of the constraints (I'm only running one robot, the constraints don't change during runtime).  This causes me to have to write ugly code in order to accept a list of points, getting the first two by index and then calling subList and converting that sub list to an array.

The secondary reasoning is that the paths are simply reconstructed into an ArrayList at the end of the day already.  It doesn't make sense to convert away from a List back into a List.

As other options on this PR, I'm unsure whether it would be better to keep a vararg overload.  If this is desired, I can add one.  Also, it may be easier to add overloads that take Lists, however this adds a lot of unnecessary code for the Lists to be turned into arrays for varargs to be turned right back into a List.

Feel free to deny if this is actively not desired.