### PR TITLE
Transform path states based on alliance color

### DIFF
--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -126,6 +126,42 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
 
         _animController.forward();
       });
+
+      if (!(widget.prefs.getBool('seen2023Warning') ?? false)) {
+        showDialog(
+            context: this.context,
+            barrierDismissible: false,
+            builder: (context) {
+              return AlertDialog(
+                title: const Text('Non-standard Field Mirroring'),
+                content: SizedBox(
+                  width: 300,
+                  child: Column(
+                    mainAxisSize: MainAxisSize.min,
+                    children: const [
+                      Text(
+                          'The 2023 FRC game has non-standard field mirroring that would prevent using the same auto path for both alliances.'),
+                      SizedBox(height: 16),
+                      Text(
+                          'To work around this, PathPlannerLib has added functionality to automatically transform paths to work for the correct alliance depending on the current alliance color while using PathPlannerLib\'s path following commands.'),
+                      SizedBox(height: 16),
+                      Text(
+                          'In order for this to work correctly, you MUST create all of your paths on the blue (left) side of the field.'),
+                    ],
+                  ),
+                ),
+                actions: [
+                  TextButton(
+                    onPressed: () {
+                      Navigator.of(context).pop();
+                      widget.prefs.setBool('seen2023Warning', true);
+                    },
+                    child: const Text('OK'),
+                  ),
+                ],
+              );
+            });
+      }
     });
   }
 

--- a/pathplannerlib/.vscode/settings.json
+++ b/pathplannerlib/.vscode/settings.json
@@ -76,6 +76,12 @@
     "semaphore": "cpp",
     "span": "cpp",
     "stop_token": "cpp",
-    "variant": "cpp"
-}
+    "variant": "cpp",
+    "xhash": "cpp",
+    "xmemory": "cpp",
+    "xstddef": "cpp",
+    "xstring": "cpp",
+    "xtr1common": "cpp",
+    "xutility": "cpp"
+  }
 }

--- a/pathplannerlib/publish.gradle
+++ b/pathplannerlib/publish.gradle
@@ -2,7 +2,7 @@ apply plugin: 'maven-publish'
 
 ext.licenseFile = files("$rootDir/LICENSE.txt")
 
-def pubVersion = '2023.2.3'
+def pubVersion = '2023.3.0'
 
 def outputsFolder = file("$buildDir/outputs")
 

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/PathPlanner.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/PathPlanner.java
@@ -42,7 +42,7 @@ public class PathPlanner {
       List<Waypoint> waypoints = getWaypointsFromJson(json);
       List<EventMarker> markers = getMarkersFromJson(json);
 
-      return new PathPlannerTrajectory(waypoints, markers, constraints, reversed);
+      return new PathPlannerTrajectory(waypoints, markers, constraints, reversed, true);
     } catch (Exception e) {
       e.printStackTrace();
       return null;
@@ -166,7 +166,11 @@ public class PathPlanner {
 
         pathGroup.add(
             new PathPlannerTrajectory(
-                splitWaypoints.get(i), splitMarkers.get(i), currentConstraints, shouldReverse));
+                splitWaypoints.get(i),
+                splitMarkers.get(i),
+                currentConstraints,
+                shouldReverse,
+                true));
 
         // Loop through waypoints and invert shouldReverse for every reversal point.
         // This makes sure that other paths in the group are properly reversed.
@@ -293,7 +297,7 @@ public class PathPlanner {
               new PathPlannerTrajectory.StopEvent()));
     }
 
-    return new PathPlannerTrajectory(waypoints, new ArrayList<>(), constraints, reversed);
+    return new PathPlannerTrajectory(waypoints, new ArrayList<>(), constraints, reversed, false);
   }
 
   /**

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/PathPlannerTrajectory.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/PathPlannerTrajectory.java
@@ -16,25 +16,29 @@ public class PathPlannerTrajectory extends Trajectory {
   private final List<EventMarker> markers;
   private final StopEvent startStopEvent;
   private final StopEvent endStopEvent;
+  public final boolean fromGUI;
 
   public PathPlannerTrajectory() {
     super();
     this.markers = new ArrayList<>();
     this.startStopEvent = new StopEvent();
     this.endStopEvent = new StopEvent();
+    this.fromGUI = false;
   }
 
   protected PathPlannerTrajectory(
       List<Waypoint> pathPoints,
       List<EventMarker> markers,
       PathConstraints constraints,
-      boolean reversed) {
+      boolean reversed,
+      boolean fromGUI) {
     super(generatePath(pathPoints, constraints.maxVelocity, constraints.maxAcceleration, reversed));
 
     this.markers = markers;
     this.calculateMarkerTimes(pathPoints);
     this.startStopEvent = pathPoints.get(0).stopEvent;
     this.endStopEvent = pathPoints.get(pathPoints.size() - 1).stopEvent;
+    this.fromGUI = fromGUI;
   }
 
   /**

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/commands/PPMecanumControllerCommand.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/commands/PPMecanumControllerCommand.java
@@ -75,13 +75,11 @@ public class PPMecanumControllerCommand extends CommandBase {
 
     addRequirements(requirements);
 
-    if (useAllianceColor
-        && trajectory.fromGUI
-        && trajectory.getInitialState().poseMeters.getX() > 8.27) {
+    if (useAllianceColor && trajectory.fromGUI && trajectory.getInitialPose().getX() > 8.27) {
       DriverStation.reportWarning(
           "You have constructed a path following command that will automatically transform path states depending"
-              + "on the alliance color, however, it appears this path was created on the red side of the field"
-              + "instead of the blue side. This is likely an error.",
+              + " on the alliance color, however, it appears this path was created on the red side of the field"
+              + " instead of the blue side. This is likely an error.",
           false);
     }
   }
@@ -165,13 +163,11 @@ public class PPMecanumControllerCommand extends CommandBase {
 
     addRequirements(requirements);
 
-    if (useAllianceColor
-        && trajectory.fromGUI
-        && trajectory.getInitialState().poseMeters.getX() > 8.27) {
+    if (useAllianceColor && trajectory.fromGUI && trajectory.getInitialPose().getX() > 8.27) {
       DriverStation.reportWarning(
           "You have constructed a path following command that will automatically transform path states depending"
-              + "on the alliance color, however, it appears this path was created on the red side of the field"
-              + "instead of the blue side. This is likely an error.",
+              + " on the alliance color, however, it appears this path was created on the red side of the field"
+              + " instead of the blue side. This is likely an error.",
           false);
     }
   }

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/commands/PPRamseteCommand.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/commands/PPRamseteCommand.java
@@ -88,13 +88,11 @@ public class PPRamseteCommand extends CommandBase {
 
     addRequirements(requirements);
 
-    if (useAllianceColor
-        && trajectory.fromGUI
-        && trajectory.getInitialState().poseMeters.getX() > 8.27) {
+    if (useAllianceColor && trajectory.fromGUI && trajectory.getInitialPose().getX() > 8.27) {
       DriverStation.reportWarning(
           "You have constructed a path following command that will automatically transform path states depending"
-              + "on the alliance color, however, it appears this path was created on the red side of the field"
-              + "instead of the blue side. This is likely an error.",
+              + " on the alliance color, however, it appears this path was created on the red side of the field"
+              + " instead of the blue side. This is likely an error.",
           false);
     }
   }
@@ -186,13 +184,11 @@ public class PPRamseteCommand extends CommandBase {
 
     addRequirements(requirements);
 
-    if (useAllianceColor
-        && trajectory.fromGUI
-        && trajectory.getInitialState().poseMeters.getX() > 8.27) {
+    if (useAllianceColor && trajectory.fromGUI && trajectory.getInitialPose().getX() > 8.27) {
       DriverStation.reportWarning(
           "You have constructed a path following command that will automatically transform path states depending"
-              + "on the alliance color, however, it appears this path was created on the red side of the field"
-              + "instead of the blue side. This is likely an error.",
+              + " on the alliance color, however, it appears this path was created on the red side of the field"
+              + " instead of the blue side. This is likely an error.",
           false);
     }
   }

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/commands/PPRamseteCommand.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/commands/PPRamseteCommand.java
@@ -9,6 +9,7 @@ import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.math.kinematics.DifferentialDriveKinematics;
 import edu.wpi.first.math.kinematics.DifferentialDriveWheelSpeeds;
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
@@ -29,10 +30,74 @@ public class PPRamseteCommand extends CommandBase {
   private final PIDController leftController;
   private final PIDController rightController;
   private final BiConsumer<Double, Double> output;
+  private final boolean useAllianceColor;
   private final Field2d field = new Field2d();
 
   private DifferentialDriveWheelSpeeds prevSpeeds;
   private double prevTime;
+
+  /**
+   * Constructs a new PPRamseteCommand that, when executed, will follow the provided trajectory. PID
+   * control and feedforward are handled internally, and outputs are scaled -12 to 12 representing
+   * units of volts.
+   *
+   * <p>Note: The controller will *not* set the outputVolts to zero upon completion of the path -
+   * this is left to the user, since it is not appropriate for paths with nonstationary endstates.
+   *
+   * @param trajectory The trajectory to follow.
+   * @param poseSupplier A function that supplies the robot pose - use one of the odometry classes
+   *     to provide this.
+   * @param controller The RAMSETE controller used to follow the trajectory.
+   * @param feedforward The feedforward to use for the drive.
+   * @param kinematics The kinematics for the robot drivetrain.
+   * @param speedsSupplier A function that supplies the speeds of the left and right sides of the
+   *     robot drive.
+   * @param leftController The PIDController for the left side of the robot drive.
+   * @param rightController The PIDController for the right side of the robot drive.
+   * @param outputVolts A function that consumes the computed left and right outputs (in volts) for
+   *     the robot drive.
+   * @param useAllianceColor Should the path states be automatically transformed based on alliance
+   *     color? In order for this to work properly, you MUST create your path on the blue side of
+   *     the field.
+   * @param requirements The subsystems to require.
+   */
+  public PPRamseteCommand(
+      PathPlannerTrajectory trajectory,
+      Supplier<Pose2d> poseSupplier,
+      RamseteController controller,
+      SimpleMotorFeedforward feedforward,
+      DifferentialDriveKinematics kinematics,
+      Supplier<DifferentialDriveWheelSpeeds> speedsSupplier,
+      PIDController leftController,
+      PIDController rightController,
+      BiConsumer<Double, Double> outputVolts,
+      boolean useAllianceColor,
+      Subsystem... requirements) {
+    this.trajectory = trajectory;
+    this.poseSupplier = poseSupplier;
+    this.controller = controller;
+    this.feedforward = feedforward;
+    this.kinematics = kinematics;
+    this.speedsSupplier = speedsSupplier;
+    this.leftController = leftController;
+    this.rightController = rightController;
+    this.output = outputVolts;
+    this.useAllianceColor = useAllianceColor;
+
+    this.usePID = true;
+
+    addRequirements(requirements);
+
+    if (useAllianceColor
+        && trajectory.fromGUI
+        && trajectory.getInitialState().poseMeters.getX() > 8.27) {
+      DriverStation.reportWarning(
+          "You have constructed a path following command that will automatically transform path states depending"
+              + "on the alliance color, however, it appears this path was created on the red side of the field"
+              + "instead of the blue side. This is likely an error.",
+          false);
+    }
+  }
 
   /**
    * Constructs a new PPRamseteCommand that, when executed, will follow the provided trajectory. PID
@@ -67,19 +132,69 @@ public class PPRamseteCommand extends CommandBase {
       PIDController rightController,
       BiConsumer<Double, Double> outputVolts,
       Subsystem... requirements) {
+    this(
+        trajectory,
+        poseSupplier,
+        controller,
+        feedforward,
+        kinematics,
+        speedsSupplier,
+        leftController,
+        rightController,
+        outputVolts,
+        true,
+        requirements);
+  }
+
+  /**
+   * Constructs a new PPRamseteCommand that, when executed, will follow the provided trajectory.
+   * Performs no PID control and calculates no feedforwards; outputs are the raw wheel speeds from
+   * the RAMSETE controller, and will need to be converted into a usable form by the user.
+   *
+   * @param trajectory The trajectory to follow.
+   * @param poseSupplier A function that supplies the robot pose - use one of the odometry classes
+   *     to provide this.
+   * @param controller The RAMSETE follower used to follow the trajectory.
+   * @param kinematics The kinematics for the robot drivetrain.
+   * @param outputMetersPerSecond A function that consumes the computed left and right wheel speeds.
+   * @param useAllianceColor Should the path states be automatically transformed based on alliance
+   *     color? In order for this to work properly, you MUST create your path on the blue side of
+   *     the field.
+   * @param requirements The subsystems to require.
+   */
+  public PPRamseteCommand(
+      PathPlannerTrajectory trajectory,
+      Supplier<Pose2d> poseSupplier,
+      RamseteController controller,
+      DifferentialDriveKinematics kinematics,
+      BiConsumer<Double, Double> outputMetersPerSecond,
+      boolean useAllianceColor,
+      Subsystem... requirements) {
     this.trajectory = trajectory;
     this.poseSupplier = poseSupplier;
     this.controller = controller;
-    this.feedforward = feedforward;
     this.kinematics = kinematics;
-    this.speedsSupplier = speedsSupplier;
-    this.leftController = leftController;
-    this.rightController = rightController;
-    this.output = outputVolts;
+    this.output = outputMetersPerSecond;
 
-    this.usePID = true;
+    this.feedforward = null;
+    this.speedsSupplier = null;
+    this.leftController = null;
+    this.rightController = null;
+    this.useAllianceColor = useAllianceColor;
+
+    this.usePID = false;
 
     addRequirements(requirements);
+
+    if (useAllianceColor
+        && trajectory.fromGUI
+        && trajectory.getInitialState().poseMeters.getX() > 8.27) {
+      DriverStation.reportWarning(
+          "You have constructed a path following command that will automatically transform path states depending"
+              + "on the alliance color, however, it appears this path was created on the red side of the field"
+              + "instead of the blue side. This is likely an error.",
+          false);
+    }
   }
 
   /**
@@ -102,20 +217,14 @@ public class PPRamseteCommand extends CommandBase {
       DifferentialDriveKinematics kinematics,
       BiConsumer<Double, Double> outputMetersPerSecond,
       Subsystem... requirements) {
-    this.trajectory = trajectory;
-    this.poseSupplier = poseSupplier;
-    this.controller = controller;
-    this.kinematics = kinematics;
-    this.output = outputMetersPerSecond;
-
-    this.feedforward = null;
-    this.speedsSupplier = null;
-    this.leftController = null;
-    this.rightController = null;
-
-    this.usePID = false;
-
-    addRequirements(requirements);
+    this(
+        trajectory,
+        poseSupplier,
+        controller,
+        kinematics,
+        outputMetersPerSecond,
+        true,
+        requirements);
   }
 
   @Override
@@ -126,6 +235,11 @@ public class PPRamseteCommand extends CommandBase {
     this.field.getObject("traj").setTrajectory(this.trajectory);
 
     PathPlannerTrajectory.PathPlannerState initialState = this.trajectory.getInitialState();
+    if (useAllianceColor && trajectory.fromGUI) {
+      initialState =
+          PathPlannerTrajectory.transformStateForAlliance(
+              initialState, DriverStation.getAlliance());
+    }
     this.prevSpeeds =
         this.kinematics.toWheelSpeeds(
             new ChassisSpeeds(
@@ -157,6 +271,11 @@ public class PPRamseteCommand extends CommandBase {
     Pose2d currentPose = this.poseSupplier.get();
     PathPlannerTrajectory.PathPlannerState desiredState =
         (PathPlannerTrajectory.PathPlannerState) this.trajectory.sample(currentTime);
+    if (useAllianceColor && trajectory.fromGUI) {
+      desiredState =
+          PathPlannerTrajectory.transformStateForAlliance(
+              desiredState, DriverStation.getAlliance());
+    }
     this.field.setRobotPose(currentPose);
     PathPlannerServer.sendPathFollowingData(desiredState.poseMeters, currentPose);
 

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/commands/PPSwerveControllerCommand.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/commands/PPSwerveControllerCommand.java
@@ -9,6 +9,7 @@ import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.kinematics.ChassisSpeeds;
 import edu.wpi.first.math.kinematics.SwerveDriveKinematics;
 import edu.wpi.first.math.kinematics.SwerveModuleState;
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj.Timer;
 import edu.wpi.first.wpilibj.smartdashboard.Field2d;
 import edu.wpi.first.wpilibj.smartdashboard.SmartDashboard;
@@ -26,7 +27,59 @@ public class PPSwerveControllerCommand extends CommandBase {
   private final Consumer<SwerveModuleState[]> outputModuleStates;
   private final Consumer<ChassisSpeeds> outputChassisSpeeds;
   private final boolean useKinematics;
+  private final boolean useAllianceColor;
   private final Field2d field = new Field2d();
+
+  /**
+   * Constructs a new PPSwerveControllerCommand that when executed will follow the provided
+   * trajectory. This command will not return output voltages but ChassisSpeeds from the position
+   * controllers which need to be converted to module states and put into a velocity PID.
+   *
+   * <p>Note: The controllers will *not* set the output to zero upon completion of the path this is
+   * left to the user, since it is not appropriate for paths with nonstationary endstates.
+   *
+   * @param trajectory The trajectory to follow.
+   * @param poseSupplier A function that supplies the robot pose - use one of the odometry classes
+   *     to provide this.
+   * @param xController The Trajectory Tracker PID controller for the robot's x position.
+   * @param yController The Trajectory Tracker PID controller for the robot's y position.
+   * @param rotationController The Trajectory Tracker PID controller for angle for the robot.
+   * @param outputChassisSpeeds The field relative chassis speeds output consumer.
+   * @param useAllianceColor Should the path states be automatically transformed based on alliance
+   *     color? In order for this to work properly, you MUST create your path on the blue side of
+   *     the field.
+   * @param requirements The subsystems to require.
+   */
+  public PPSwerveControllerCommand(
+      PathPlannerTrajectory trajectory,
+      Supplier<Pose2d> poseSupplier,
+      PIDController xController,
+      PIDController yController,
+      PIDController rotationController,
+      Consumer<ChassisSpeeds> outputChassisSpeeds,
+      boolean useAllianceColor,
+      Subsystem... requirements) {
+    this.trajectory = trajectory;
+    this.poseSupplier = poseSupplier;
+    this.controller = new PPHolonomicDriveController(xController, yController, rotationController);
+    this.outputChassisSpeeds = outputChassisSpeeds;
+    this.outputModuleStates = null;
+    this.kinematics = null;
+    this.useKinematics = false;
+    this.useAllianceColor = useAllianceColor;
+
+    addRequirements(requirements);
+
+    if (useAllianceColor
+        && trajectory.fromGUI
+        && trajectory.getInitialState().poseMeters.getX() > 8.27) {
+      DriverStation.reportWarning(
+          "You have constructed a path following command that will automatically transform path states depending"
+              + "on the alliance color, however, it appears this path was created on the red side of the field"
+              + "instead of the blue side. This is likely an error.",
+          false);
+    }
+  }
 
   /**
    * Constructs a new PPSwerveControllerCommand that when executed will follow the provided
@@ -53,15 +106,68 @@ public class PPSwerveControllerCommand extends CommandBase {
       PIDController rotationController,
       Consumer<ChassisSpeeds> outputChassisSpeeds,
       Subsystem... requirements) {
+    this(
+        trajectory,
+        poseSupplier,
+        xController,
+        yController,
+        rotationController,
+        outputChassisSpeeds,
+        true,
+        requirements);
+  }
+
+  /**
+   * Constructs a new PPSwerveControllerCommand that when executed will follow the provided
+   * trajectory. This command will not return output voltages but rather raw module states from the
+   * position controllers which need to be put into a velocity PID.
+   *
+   * <p>Note: The controllers will *not* set the output to zero upon completion of the path- this is
+   * left to the user, since it is not appropriate for paths with nonstationary endstates.
+   *
+   * @param trajectory The trajectory to follow.
+   * @param poseSupplier A function that supplies the robot pose - use one of the odometry classes
+   *     to provide this.
+   * @param kinematics The kinematics for the robot drivetrain.
+   * @param xController The Trajectory Tracker PID controller for the robot's x position.
+   * @param yController The Trajectory Tracker PID controller for the robot's y position.
+   * @param rotationController The Trajectory Tracker PID controller for angle for the robot.
+   * @param outputModuleStates The raw output module states from the position controllers.
+   * @param useAllianceColor Should the path states be automatically transformed based on alliance
+   *     color? In order for this to work properly, you MUST create your path on the blue side of
+   *     the field.
+   * @param requirements The subsystems to require.
+   */
+  public PPSwerveControllerCommand(
+      PathPlannerTrajectory trajectory,
+      Supplier<Pose2d> poseSupplier,
+      SwerveDriveKinematics kinematics,
+      PIDController xController,
+      PIDController yController,
+      PIDController rotationController,
+      Consumer<SwerveModuleState[]> outputModuleStates,
+      boolean useAllianceColor,
+      Subsystem... requirements) {
     this.trajectory = trajectory;
     this.poseSupplier = poseSupplier;
+    this.kinematics = kinematics;
     this.controller = new PPHolonomicDriveController(xController, yController, rotationController);
-    this.outputChassisSpeeds = outputChassisSpeeds;
-    this.outputModuleStates = null;
-    this.kinematics = null;
-    this.useKinematics = false;
+    this.outputModuleStates = outputModuleStates;
+    this.outputChassisSpeeds = null;
+    this.useKinematics = true;
+    this.useAllianceColor = useAllianceColor;
 
     addRequirements(requirements);
+
+    if (useAllianceColor
+        && trajectory.fromGUI
+        && trajectory.getInitialState().poseMeters.getX() > 8.27) {
+      DriverStation.reportWarning(
+          "You have constructed a path following command that will automatically transform path states depending"
+              + "on the alliance color, however, it appears this path was created on the red side of the field"
+              + "instead of the blue side. This is likely an error.",
+          false);
+    }
   }
 
   /**
@@ -91,15 +197,16 @@ public class PPSwerveControllerCommand extends CommandBase {
       PIDController rotationController,
       Consumer<SwerveModuleState[]> outputModuleStates,
       Subsystem... requirements) {
-    this.trajectory = trajectory;
-    this.poseSupplier = poseSupplier;
-    this.kinematics = kinematics;
-    this.controller = new PPHolonomicDriveController(xController, yController, rotationController);
-    this.outputModuleStates = outputModuleStates;
-    this.outputChassisSpeeds = null;
-    this.useKinematics = true;
-
-    addRequirements(requirements);
+    this(
+        trajectory,
+        poseSupplier,
+        kinematics,
+        xController,
+        yController,
+        rotationController,
+        outputModuleStates,
+        true,
+        requirements);
   }
 
   @Override
@@ -117,6 +224,12 @@ public class PPSwerveControllerCommand extends CommandBase {
   public void execute() {
     double currentTime = this.timer.get();
     PathPlannerState desiredState = (PathPlannerState) this.trajectory.sample(currentTime);
+
+    if (useAllianceColor && trajectory.fromGUI) {
+      desiredState =
+          PathPlannerTrajectory.transformStateForAlliance(
+              desiredState, DriverStation.getAlliance());
+    }
 
     Pose2d currentPose = this.poseSupplier.get();
     this.field.setRobotPose(currentPose);

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/commands/PPSwerveControllerCommand.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/commands/PPSwerveControllerCommand.java
@@ -70,13 +70,11 @@ public class PPSwerveControllerCommand extends CommandBase {
 
     addRequirements(requirements);
 
-    if (useAllianceColor
-        && trajectory.fromGUI
-        && trajectory.getInitialState().poseMeters.getX() > 8.27) {
+    if (useAllianceColor && trajectory.fromGUI && trajectory.getInitialPose().getX() > 8.27) {
       DriverStation.reportWarning(
           "You have constructed a path following command that will automatically transform path states depending"
-              + "on the alliance color, however, it appears this path was created on the red side of the field"
-              + "instead of the blue side. This is likely an error.",
+              + " on the alliance color, however, it appears this path was created on the red side of the field"
+              + " instead of the blue side. This is likely an error.",
           false);
     }
   }
@@ -159,13 +157,11 @@ public class PPSwerveControllerCommand extends CommandBase {
 
     addRequirements(requirements);
 
-    if (useAllianceColor
-        && trajectory.fromGUI
-        && trajectory.getInitialState().poseMeters.getX() > 8.27) {
+    if (useAllianceColor && trajectory.fromGUI && trajectory.getInitialPose().getX() > 8.27) {
       DriverStation.reportWarning(
           "You have constructed a path following command that will automatically transform path states depending"
-              + "on the alliance color, however, it appears this path was created on the red side of the field"
-              + "instead of the blue side. This is likely an error.",
+              + " on the alliance color, however, it appears this path was created on the red side of the field"
+              + " instead of the blue side. This is likely an error.",
           false);
     }
   }

--- a/pathplannerlib/src/main/native/cpp/pathplanner/lib/PathPlanner.cpp
+++ b/pathplannerlib/src/main/native/cpp/pathplanner/lib/PathPlanner.cpp
@@ -33,7 +33,8 @@ PathPlannerTrajectory PathPlanner::loadPath(std::string const &name,
 	std::vector < PathPlannerTrajectory::EventMarker > markers =
 			getMarkersFromJson(json);
 
-	return PathPlannerTrajectory(waypoints, markers, constraints, reversed);
+	return PathPlannerTrajectory(waypoints, markers, constraints, reversed,
+			true);
 }
 
 std::vector<PathPlannerTrajectory> PathPlanner::loadPathGroup(
@@ -115,7 +116,7 @@ std::vector<PathPlannerTrajectory> PathPlanner::loadPathGroup(
 						constraints[constraints.size() - 1] : constraints[i];
 
 		pathGroup.emplace_back(splitWaypoints[i], splitMarkers[i],
-				currentConstraints, shouldReverse);
+				currentConstraints, shouldReverse, true);
 
 		// Loop through waypoints and invert shouldReverse for every reversal point.
 		// This makes sure that other paths in the group are properly reversed.
@@ -174,7 +175,7 @@ PathPlannerTrajectory PathPlanner::generatePath(
 
 	return PathPlannerTrajectory(waypoints,
 			std::vector<PathPlannerTrajectory::EventMarker>(), constraints,
-			reversed);
+			reversed, false);
 }
 
 PathPlannerTrajectory PathPlanner::generatePath(

--- a/pathplannerlib/src/main/native/cpp/pathplanner/lib/PathPlannerTrajectory.cpp
+++ b/pathplannerlib/src/main/native/cpp/pathplanner/lib/PathPlannerTrajectory.cpp
@@ -389,7 +389,7 @@ PathPlannerTrajectory::PathPlannerState PathPlannerTrajectory::sample(
 			(time - prevSample.time) / (sample.time - prevSample.time));
 }
 
-PathPlannerTrajectory::PathPlannerState PathPlannerTrajectory::transformForAlliance(
+PathPlannerTrajectory::PathPlannerState PathPlannerTrajectory::transformStateForAlliance(
 		PathPlannerState const &state,
 		frc::DriverStation::Alliance const alliance) {
 	if (alliance == frc::DriverStation::Alliance::kRed) {

--- a/pathplannerlib/src/main/native/cpp/pathplanner/lib/PathPlannerTrajectory.cpp
+++ b/pathplannerlib/src/main/native/cpp/pathplanner/lib/PathPlannerTrajectory.cpp
@@ -356,13 +356,12 @@ units::meter_t PathPlannerTrajectory::calculateRadius(
 }
 
 PathPlannerTrajectory::PathPlannerState PathPlannerTrajectory::sample(
-		units::second_t const time,
-		frc::DriverStation::Alliance const alliance) const {
+		units::second_t const time) const {
 	if (time <= getInitialState().time) {
-		return transformForAlliance(getInitialState(), alliance);
+		return getInitialState();
 	}
 	if (time >= getTotalTime()) {
-		return transformForAlliance(getEndState(), alliance);
+		return getEndState();
 	}
 
 	int low = 1;
@@ -381,18 +380,16 @@ PathPlannerTrajectory::PathPlannerState PathPlannerTrajectory::sample(
 	PathPlannerState const &prevSample = getState(low - 1);
 
 	if (units::math::abs(sample.time - prevSample.time) < 0.001_s) {
-		return transformForAlliance(sample, alliance);
+		return sample;
 	}
 
-	return transformForAlliance(
-			prevSample.interpolate(sample,
-					(time - prevSample.time) / (sample.time - prevSample.time)),
-			alliance);
+	return prevSample.interpolate(sample,
+			(time - prevSample.time) / (sample.time - prevSample.time));
 }
 
 PathPlannerTrajectory::PathPlannerState PathPlannerTrajectory::transformForAlliance(
 		PathPlannerState const &state,
-		frc::DriverStation::Alliance const alliance) const {
+		frc::DriverStation::Alliance const alliance) {
 	if (alliance == frc::DriverStation::Alliance::kRed) {
 		// Create a new state so that we don't overwrite the original
 		PathPlannerTrajectory::PathPlannerState transformedState;

--- a/pathplannerlib/src/main/native/cpp/pathplanner/lib/PathPlannerTrajectory.cpp
+++ b/pathplannerlib/src/main/native/cpp/pathplanner/lib/PathPlannerTrajectory.cpp
@@ -10,7 +10,8 @@ using namespace pathplanner;
 PathPlannerTrajectory::PathPlannerTrajectory(
 		std::vector<Waypoint> const &waypoints,
 		std::vector<EventMarker> const &markers,
-		PathConstraints const constraints, bool const reversed) {
+		PathConstraints const constraints, bool const reversed,
+		bool const fromGUI) {
 	this->states = generatePath(waypoints, constraints.maxVelocity,
 			constraints.maxAcceleration, reversed);
 
@@ -19,6 +20,7 @@ PathPlannerTrajectory::PathPlannerTrajectory(
 
 	this->startStopEvent = waypoints[0].stopEvent;
 	this->endStopEvent = waypoints[waypoints.size() - 1].stopEvent;
+	this->fromGUI = fromGUI;
 }
 
 std::vector<PathPlannerTrajectory::PathPlannerState> PathPlannerTrajectory::generatePath(

--- a/pathplannerlib/src/main/native/cpp/pathplanner/lib/commands/PPMecanumControllerCommand.cpp
+++ b/pathplannerlib/src/main/native/cpp/pathplanner/lib/commands/PPMecanumControllerCommand.cpp
@@ -1,6 +1,7 @@
 #include "pathplanner/lib/commands/PPMecanumControllerCommand.h"
 
 #include <frc/smartdashboard/SmartDashboard.h>
+#include <frc/DriverStation.h>
 
 using namespace pathplanner;
 
@@ -9,13 +10,39 @@ PPMecanumControllerCommand::PPMecanumControllerCommand(
 		frc2::PIDController xController, frc2::PIDController yController,
 		frc::PIDController thetaController,
 		std::function<void(frc::ChassisSpeeds)> output,
-		std::initializer_list<frc2::Subsystem*> requirements) : m_trajectory(
+		std::initializer_list<frc2::Subsystem*> requirements,
+		bool useAllianceColor) : m_trajectory(std::move(trajectory)), m_pose(
+		std::move(pose)), m_kinematics(frc::Translation2d(),
+		frc::Translation2d(), frc::Translation2d(), frc::Translation2d()), m_controller(
+		xController, yController, thetaController), m_maxWheelVelocity(0_mps), m_outputChassisSpeeds(
+		output), m_useKinematics(false), m_useAllianceColor(useAllianceColor) {
+	this->AddRequirements(requirements);
+
+	if (m_useAllianceColor && m_trajectory.fromGUI
+			&& m_trajectory.getInitialPose().X() > 8.27_m) {
+		FRC_ReportError(frc::warn::Warning,
+				"You have constructed a path following command that will automatically transform path states depending on the alliance color, however, it appears this path was created on the red side of the field instead of the blue side. This is likely an error.");
+	}
+}
+
+PPMecanumControllerCommand::PPMecanumControllerCommand(
+		PathPlannerTrajectory trajectory, std::function<frc::Pose2d()> pose,
+		frc2::PIDController xController, frc2::PIDController yController,
+		frc::PIDController thetaController,
+		std::function<void(frc::ChassisSpeeds)> output,
+		std::span<frc2::Subsystem* const > requirements, bool useAllianceColor) : m_trajectory(
 		std::move(trajectory)), m_pose(std::move(pose)), m_kinematics(
 		frc::Translation2d(), frc::Translation2d(), frc::Translation2d(),
 		frc::Translation2d()), m_controller(xController, yController,
 		thetaController), m_maxWheelVelocity(0_mps), m_outputChassisSpeeds(
-		output), m_useKinematics(false) {
+		output), m_useKinematics(false), m_useAllianceColor(useAllianceColor) {
 	this->AddRequirements(requirements);
+
+	if (m_useAllianceColor && m_trajectory.fromGUI
+			&& m_trajectory.getInitialPose().X() > 8.27_m) {
+		FRC_ReportError(frc::warn::Warning,
+				"You have constructed a path following command that will automatically transform path states depending on the alliance color, however, it appears this path was created on the red side of the field instead of the blue side. This is likely an error.");
+	}
 }
 
 PPMecanumControllerCommand::PPMecanumControllerCommand(
@@ -24,11 +51,38 @@ PPMecanumControllerCommand::PPMecanumControllerCommand(
 		frc2::PIDController yController, frc::PIDController thetaController,
 		units::meters_per_second_t maxWheelVelocity,
 		std::function<void(frc::MecanumDriveWheelSpeeds)> output,
-		std::span<frc2::Subsystem* const > requirements) : m_trajectory(
+		std::initializer_list<frc2::Subsystem*> requirements,
+		bool useAllianceColor) : m_trajectory(std::move(trajectory)), m_pose(
+		std::move(pose)), m_kinematics(kinematics), m_controller(xController,
+		yController, thetaController), m_maxWheelVelocity(maxWheelVelocity), m_outputVel(
+		output), m_useKinematics(true), m_useAllianceColor(useAllianceColor) {
+	this->AddRequirements(requirements);
+
+	if (m_useAllianceColor && m_trajectory.fromGUI
+			&& m_trajectory.getInitialPose().X() > 8.27_m) {
+		FRC_ReportError(frc::warn::Warning,
+				"You have constructed a path following command that will automatically transform path states depending on the alliance color, however, it appears this path was created on the red side of the field instead of the blue side. This is likely an error.");
+	}
+}
+
+PPMecanumControllerCommand::PPMecanumControllerCommand(
+		PathPlannerTrajectory trajectory, std::function<frc::Pose2d()> pose,
+		frc::MecanumDriveKinematics kinematics, frc2::PIDController xController,
+		frc2::PIDController yController, frc::PIDController thetaController,
+		units::meters_per_second_t maxWheelVelocity,
+		std::function<void(frc::MecanumDriveWheelSpeeds)> output,
+		std::span<frc2::Subsystem* const > requirements, bool useAllianceColor) : m_trajectory(
 		std::move(trajectory)), m_pose(std::move(pose)), m_kinematics(
 		kinematics), m_controller(xController, yController, thetaController), m_maxWheelVelocity(
-		maxWheelVelocity), m_outputVel(output), m_useKinematics(true) {
+		maxWheelVelocity), m_outputVel(output), m_useKinematics(true), m_useAllianceColor(
+		useAllianceColor) {
 	this->AddRequirements(requirements);
+
+	if (m_useAllianceColor && m_trajectory.fromGUI
+			&& m_trajectory.getInitialPose().X() > 8.27_m) {
+		FRC_ReportError(frc::warn::Warning,
+				"You have constructed a path following command that will automatically transform path states depending on the alliance color, however, it appears this path was created on the red side of the field instead of the blue side. This is likely an error.");
+	}
 }
 
 void PPMecanumControllerCommand::Initialize() {
@@ -44,6 +98,11 @@ void PPMecanumControllerCommand::Initialize() {
 void PPMecanumControllerCommand::Execute() {
 	auto currentTime = m_timer.Get();
 	auto desiredState = m_trajectory.sample(currentTime);
+
+	if (m_useAllianceColor && m_trajectory.fromGUI) {
+		desiredState = PathPlannerTrajectory::transformForAlliance(desiredState,
+				frc::DriverStation::GetAlliance());
+	}
 
 	frc::Pose2d currentPose = m_pose();
 	m_field.SetRobotPose(currentPose);

--- a/pathplannerlib/src/main/native/cpp/pathplanner/lib/commands/PPMecanumControllerCommand.cpp
+++ b/pathplannerlib/src/main/native/cpp/pathplanner/lib/commands/PPMecanumControllerCommand.cpp
@@ -100,8 +100,8 @@ void PPMecanumControllerCommand::Execute() {
 	auto desiredState = m_trajectory.sample(currentTime);
 
 	if (m_useAllianceColor && m_trajectory.fromGUI) {
-		desiredState = PathPlannerTrajectory::transformForAlliance(desiredState,
-				frc::DriverStation::GetAlliance());
+		desiredState = PathPlannerTrajectory::transformStateForAlliance(
+				desiredState, frc::DriverStation::GetAlliance());
 	}
 
 	frc::Pose2d currentPose = m_pose();

--- a/pathplannerlib/src/main/native/cpp/pathplanner/lib/commands/PPSwerveControllerCommand.cpp
+++ b/pathplannerlib/src/main/native/cpp/pathplanner/lib/commands/PPSwerveControllerCommand.cpp
@@ -100,8 +100,8 @@ void PPSwerveControllerCommand::Execute() {
 	auto desiredState = this->m_trajectory.sample(currentTime);
 
 	if (m_useAllianceColor && m_trajectory.fromGUI) {
-		desiredState = PathPlannerTrajectory::transformForAlliance(desiredState,
-				frc::DriverStation::GetAlliance());
+		desiredState = PathPlannerTrajectory::transformStateForAlliance(
+				desiredState, frc::DriverStation::GetAlliance());
 	}
 
 	frc::Pose2d currentPose = this->m_pose();

--- a/pathplannerlib/src/main/native/cpp/pathplanner/lib/commands/PPSwerveControllerCommand.cpp
+++ b/pathplannerlib/src/main/native/cpp/pathplanner/lib/commands/PPSwerveControllerCommand.cpp
@@ -3,6 +3,7 @@
 #include <frc/smartdashboard/SmartDashboard.h>
 #include <frc/kinematics/ChassisSpeeds.h>
 #include <frc/controller/PIDController.h>
+#include <frc/DriverStation.h>
 
 using namespace pathplanner;
 
@@ -11,12 +12,38 @@ PPSwerveControllerCommand::PPSwerveControllerCommand(
 		frc2::PIDController xController, frc2::PIDController yController,
 		frc2::PIDController rotationController,
 		std::function<void(frc::ChassisSpeeds)> output,
-		std::initializer_list<frc2::Subsystem*> requirements) : m_trajectory(
+		std::initializer_list<frc2::Subsystem*> requirements,
+		bool useAllianceColor) : m_trajectory(trajectory), m_pose(pose), m_kinematics(
+		frc::Translation2d(), frc::Translation2d(), frc::Translation2d(),
+		frc::Translation2d()), m_outputChassisSpeeds(output), m_useKinematics(
+		false), m_controller(xController, yController, rotationController), m_useAllianceColor(
+		useAllianceColor) {
+	this->AddRequirements(requirements);
+
+	if (m_useAllianceColor && m_trajectory.fromGUI
+			&& m_trajectory.getInitialPose().X() > 8.27_m) {
+		FRC_ReportError(frc::warn::Warning,
+				"You have constructed a path following command that will automatically transform path states depending on the alliance color, however, it appears this path was created on the red side of the field instead of the blue side. This is likely an error.");
+	}
+}
+
+PPSwerveControllerCommand::PPSwerveControllerCommand(
+		PathPlannerTrajectory trajectory, std::function<frc::Pose2d()> pose,
+		frc2::PIDController xController, frc2::PIDController yController,
+		frc2::PIDController rotationController,
+		std::function<void(frc::ChassisSpeeds)> output,
+		std::span<frc2::Subsystem* const > requirements, bool useAllianceColor) : m_trajectory(
 		trajectory), m_pose(pose), m_kinematics(frc::Translation2d(),
 		frc::Translation2d(), frc::Translation2d(), frc::Translation2d()), m_outputChassisSpeeds(
 		output), m_useKinematics(false), m_controller(xController, yController,
-		rotationController) {
+		rotationController), m_useAllianceColor(useAllianceColor) {
 	this->AddRequirements(requirements);
+
+	if (m_useAllianceColor && m_trajectory.fromGUI
+			&& m_trajectory.getInitialPose().X() > 8.27_m) {
+		FRC_ReportError(frc::warn::Warning,
+				"You have constructed a path following command that will automatically transform path states depending on the alliance color, however, it appears this path was created on the red side of the field instead of the blue side. This is likely an error.");
+	}
 }
 
 PPSwerveControllerCommand::PPSwerveControllerCommand(
@@ -25,11 +52,37 @@ PPSwerveControllerCommand::PPSwerveControllerCommand(
 		frc2::PIDController xController, frc2::PIDController yController,
 		frc2::PIDController rotationController,
 		std::function<void(std::array<frc::SwerveModuleState, 4>)> output,
-		std::span<frc2::Subsystem* const > requirements) : m_trajectory(
+		std::initializer_list<frc2::Subsystem*> requirements,
+		bool useAllianceColor) : m_trajectory(trajectory), m_pose(pose), m_kinematics(
+		kinematics), m_outputStates(output), m_useKinematics(true), m_controller(
+		xController, yController, rotationController), m_useAllianceColor(
+		useAllianceColor) {
+	this->AddRequirements(requirements);
+
+	if (m_useAllianceColor && m_trajectory.fromGUI
+			&& m_trajectory.getInitialPose().X() > 8.27_m) {
+		FRC_ReportError(frc::warn::Warning,
+				"You have constructed a path following command that will automatically transform path states depending on the alliance color, however, it appears this path was created on the red side of the field instead of the blue side. This is likely an error.");
+	}
+}
+
+PPSwerveControllerCommand::PPSwerveControllerCommand(
+		PathPlannerTrajectory trajectory, std::function<frc::Pose2d()> pose,
+		frc::SwerveDriveKinematics<4> kinematics,
+		frc2::PIDController xController, frc2::PIDController yController,
+		frc2::PIDController rotationController,
+		std::function<void(std::array<frc::SwerveModuleState, 4>)> output,
+		std::span<frc2::Subsystem* const > requirements, bool useAllianceColor) : m_trajectory(
 		trajectory), m_pose(pose), m_kinematics(kinematics), m_outputStates(
 		output), m_useKinematics(true), m_controller(xController, yController,
-		rotationController) {
+		rotationController), m_useAllianceColor(useAllianceColor) {
 	this->AddRequirements(requirements);
+
+	if (m_useAllianceColor && m_trajectory.fromGUI
+			&& m_trajectory.getInitialPose().X() > 8.27_m) {
+		FRC_ReportError(frc::warn::Warning,
+				"You have constructed a path following command that will automatically transform path states depending on the alliance color, however, it appears this path was created on the red side of the field instead of the blue side. This is likely an error.");
+	}
 }
 
 void PPSwerveControllerCommand::Initialize() {
@@ -45,6 +98,11 @@ void PPSwerveControllerCommand::Initialize() {
 void PPSwerveControllerCommand::Execute() {
 	auto currentTime = this->m_timer.Get();
 	auto desiredState = this->m_trajectory.sample(currentTime);
+
+	if (m_useAllianceColor && m_trajectory.fromGUI) {
+		desiredState = PathPlannerTrajectory::transformForAlliance(desiredState,
+				frc::DriverStation::GetAlliance());
+	}
 
 	frc::Pose2d currentPose = this->m_pose();
 	this->m_field.SetRobotPose(currentPose);

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/PathPlannerTrajectory.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/PathPlannerTrajectory.h
@@ -178,9 +178,12 @@ private:
 public:
 	PathPlannerTrajectory(std::vector<Waypoint> const &waypoints,
 			std::vector<EventMarker> const &markers,
-			PathConstraints const constraints, bool const reversed);
+			PathConstraints const constraints, bool const reversed,
+			bool const fromGUI);
 	PathPlannerTrajectory() {
 	}
+
+	bool fromGUI;
 
 	static PathPlannerState transformForAlliance(PathPlannerState const &state,
 			frc::DriverStation::Alliance const alliance);

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/PathPlannerTrajectory.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/PathPlannerTrajectory.h
@@ -14,9 +14,11 @@
 #include <units/area.h>
 #include <units/math.h>
 #include <units/curvature.h>
+#include <frc/DriverStation.h>
 #include "PathConstraints.h"
 
 #define PI 3.14159265358979323846
+#define FIELD_WIDTH 8.02_m
 
 namespace pathplanner {
 class PathPlannerTrajectory {
@@ -171,6 +173,9 @@ private:
 
 	void calculateMarkerTimes(std::vector<Waypoint> const &pathPoints);
 
+	PathPlannerState transformForAlliance(PathPlannerState const &state,
+			frc::DriverStation::Alliance const alliance) const;
+
 	friend class PathPlanner;
 
 public:
@@ -204,7 +209,22 @@ public:
 	 * @param time The time to sample
 	 * @return The state at the given point in time
 	 */
-	PathPlannerState sample(units::second_t const time) const;
+	PathPlannerState sample(units::second_t const time) const {
+		return sample(time, frc::DriverStation::Alliance::kBlue);
+	}
+
+	/**
+	 * @brief Sample the path at a point in time for the given alliance. This is useful for dealing with
+	 * non-standard field mirroring, such as the 2023 game.
+	 * 
+	 * <p>In order for this to work properly, you must create your paths on the blue side of the field in the GUI.
+	 *
+	 * @param time The time to sample
+	 * @param alliance The current alliance color
+	 * @return The state at the given point in time, transformed if for the red alliance
+	 */
+	PathPlannerState sample(units::second_t const time,
+			frc::DriverStation::Alliance const alliance) const;
 
 	/**
 	 * @brief Get all of the states in the path

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/PathPlannerTrajectory.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/PathPlannerTrajectory.h
@@ -173,9 +173,6 @@ private:
 
 	void calculateMarkerTimes(std::vector<Waypoint> const &pathPoints);
 
-	PathPlannerState transformForAlliance(PathPlannerState const &state,
-			frc::DriverStation::Alliance const alliance) const;
-
 	friend class PathPlanner;
 
 public:
@@ -184,6 +181,9 @@ public:
 			PathConstraints const constraints, bool const reversed);
 	PathPlannerTrajectory() {
 	}
+
+	static PathPlannerState transformForAlliance(PathPlannerState const &state,
+			frc::DriverStation::Alliance const alliance);
 
 	/**
 	 * Get the "stop event" for the beginning of the path
@@ -209,22 +209,7 @@ public:
 	 * @param time The time to sample
 	 * @return The state at the given point in time
 	 */
-	PathPlannerState sample(units::second_t const time) const {
-		return sample(time, frc::DriverStation::Alliance::kBlue);
-	}
-
-	/**
-	 * @brief Sample the path at a point in time for the given alliance. This is useful for dealing with
-	 * non-standard field mirroring, such as the 2023 game.
-	 * 
-	 * <p>In order for this to work properly, you must create your paths on the blue side of the field in the GUI.
-	 *
-	 * @param time The time to sample
-	 * @param alliance The current alliance color
-	 * @return The state at the given point in time, transformed if for the red alliance
-	 */
-	PathPlannerState sample(units::second_t const time,
-			frc::DriverStation::Alliance const alliance) const;
+	PathPlannerState sample(units::second_t const time) const;
 
 	/**
 	 * @brief Get all of the states in the path

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/PathPlannerTrajectory.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/PathPlannerTrajectory.h
@@ -185,7 +185,8 @@ public:
 
 	bool fromGUI;
 
-	static PathPlannerState transformForAlliance(PathPlannerState const &state,
+	static PathPlannerState transformStateForAlliance(
+			PathPlannerState const &state,
 			frc::DriverStation::Alliance const alliance);
 
 	/**

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/commands/PPMecanumControllerCommand.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/commands/PPMecanumControllerCommand.h
@@ -58,12 +58,47 @@ public:
 	 *                         for angle for the robot.
 	 * @param output           The output of the position PIDs.
 	 * @param requirements     The subsystems to require.
+	 * @param useAllianceColor Should the path states be automatically transformed based on alliance
+	 *     color? In order for this to work properly, you MUST create your path on the blue side of
+	 *     the field.
 	 */
 	PPMecanumControllerCommand(PathPlannerTrajectory trajectory,
 			std::function<frc::Pose2d()> pose, frc2::PIDController xController,
 			frc2::PIDController yController, frc::PIDController thetaController,
 			std::function<void(frc::ChassisSpeeds)> output,
-			std::initializer_list<frc2::Subsystem*> requirements);
+			std::initializer_list<frc2::Subsystem*> requirements,
+			bool useAllianceColor = true);
+
+	/**
+	 * Constructs a new PPMecanumControllerCommand that when executed will follow
+	 * the provided trajectory. The user should implement a velocity PID on the
+	 * desired output wheel velocities.
+	 *
+	 * <p>Note: The controllers will *not* set the outputVolts to zero upon
+	 * completion of the path - this is left to the user, since it is not
+	 * appropriate for paths with non-stationary end-states.
+	 *
+	 * @param trajectory       The trajectory to follow.
+	 * @param pose             A function that supplies the robot pose - use one
+	 * of the odometry classes to provide this.
+	 * @param xController      The Trajectory Tracker PID controller
+	 *                         for the robot's x position.
+	 * @param yController      The Trajectory Tracker PID controller
+	 *                         for the robot's y position.
+	 * @param thetaController  The Trajectory Tracker PID controller
+	 *                         for angle for the robot.
+	 * @param output           The output of the position PIDs.
+	 * @param requirements     The subsystems to require.
+	 * @param useAllianceColor Should the path states be automatically transformed based on alliance
+	 *     color? In order for this to work properly, you MUST create your path on the blue side of
+	 *     the field.
+	 */
+	PPMecanumControllerCommand(PathPlannerTrajectory trajectory,
+			std::function<frc::Pose2d()> pose, frc2::PIDController xController,
+			frc2::PIDController yController, frc::PIDController thetaController,
+			std::function<void(frc::ChassisSpeeds)> output,
+			std::span<frc2::Subsystem* const > requirements = { },
+			bool useAllianceColor = true);
 
 	/**
 	 * Constructs a new PPMecanumControllerCommand that when executed will follow
@@ -87,6 +122,9 @@ public:
 	 * @param maxWheelVelocity The maximum velocity of a drivetrain wheel.
 	 * @param output           The output of the position PIDs.
 	 * @param requirements     The subsystems to require.
+	 * @param useAllianceColor Should the path states be automatically transformed based on alliance
+	 *     color? In order for this to work properly, you MUST create your path on the blue side of
+	 *     the field.
 	 */
 	PPMecanumControllerCommand(PathPlannerTrajectory trajectory,
 			std::function<frc::Pose2d()> pose,
@@ -95,7 +133,44 @@ public:
 			frc::PIDController thetaController,
 			units::meters_per_second_t maxWheelVelocity,
 			std::function<void(frc::MecanumDriveWheelSpeeds)> output,
-			std::span<frc2::Subsystem* const > requirements = { });
+			std::initializer_list<frc2::Subsystem*> requirements,
+			bool useAllianceColor = true);
+
+	/**
+	 * Constructs a new PPMecanumControllerCommand that when executed will follow
+	 * the provided trajectory. The user should implement a velocity PID on the
+	 * desired output wheel velocities.
+	 *
+	 * <p>Note: The controllers will *not* set the outputVolts to zero upon
+	 * completion of the path - this is left to the user, since it is not
+	 * appropriate for paths with non-stationary end-states.
+	 *
+	 * @param trajectory       The trajectory to follow.
+	 * @param pose             A function that supplies the robot pose - use one
+	 * of the odometry classes to provide this.
+	 * @param kinematics       The kinematics for the robot drivetrain.
+	 * @param xController      The Trajectory Tracker PID controller
+	 *                         for the robot's x position.
+	 * @param yController      The Trajectory Tracker PID controller
+	 *                         for the robot's y position.
+	 * @param thetaController  The Trajectory Tracker PID controller
+	 *                         for angle for the robot.
+	 * @param maxWheelVelocity The maximum velocity of a drivetrain wheel.
+	 * @param output           The output of the position PIDs.
+	 * @param requirements     The subsystems to require.
+	 * @param useAllianceColor Should the path states be automatically transformed based on alliance
+	 *     color? In order for this to work properly, you MUST create your path on the blue side of
+	 *     the field.
+	 */
+	PPMecanumControllerCommand(PathPlannerTrajectory trajectory,
+			std::function<frc::Pose2d()> pose,
+			frc::MecanumDriveKinematics kinematics,
+			frc2::PIDController xController, frc2::PIDController yController,
+			frc::PIDController thetaController,
+			units::meters_per_second_t maxWheelVelocity,
+			std::function<void(frc::MecanumDriveWheelSpeeds)> output,
+			std::span<frc2::Subsystem* const > requirements = { },
+			bool useAllianceColor = true);
 
 	void Initialize() override;
 
@@ -118,5 +193,7 @@ private:
 	frc::Timer m_timer;
 
 	frc::Field2d m_field;
+
+	bool m_useAllianceColor;
 };
 }

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/commands/PPSwerveControllerCommand.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/commands/PPSwerveControllerCommand.h
@@ -27,13 +27,17 @@ public:
 	 * @param rotationController The Trajectory Tracker PID controller for angle for the robot.
 	 * @param output             The raw output module states from the position controllers.
 	 * @param requirements       The subsystems to require.
+	 * @param useAllianceColor Should the path states be automatically transformed based on alliance
+	 *     color? In order for this to work properly, you MUST create your path on the blue side of
+	 *     the field.
 	 */
 	PPSwerveControllerCommand(PathPlannerTrajectory trajectory,
 			std::function<frc::Pose2d()> pose, frc2::PIDController xController,
 			frc2::PIDController yController,
 			frc2::PIDController rotationController,
 			std::function<void(frc::ChassisSpeeds)> output,
-			std::initializer_list<frc2::Subsystem*> requirements);
+			std::initializer_list<frc2::Subsystem*> requirements,
+			bool useAllianceColor = true);
 
 	/**
 	 * @brief Constructs a new PPSwerveControllerCommand that when executed will follow the
@@ -47,6 +51,33 @@ public:
 	 * @param rotationController The Trajectory Tracker PID controller for angle for the robot.
 	 * @param output             The raw output module states from the position controllers.
 	 * @param requirements       The subsystems to require.
+	 * @param useAllianceColor Should the path states be automatically transformed based on alliance
+	 *     color? In order for this to work properly, you MUST create your path on the blue side of
+	 *     the field.
+	 */
+	PPSwerveControllerCommand(PathPlannerTrajectory trajectory,
+			std::function<frc::Pose2d()> pose, frc2::PIDController xController,
+			frc2::PIDController yController,
+			frc2::PIDController rotationController,
+			std::function<void(frc::ChassisSpeeds)> output,
+			std::span<frc2::Subsystem* const > requirements = { },
+			bool useAllianceColor = true);
+
+	/**
+	 * @brief Constructs a new PPSwerveControllerCommand that when executed will follow the
+	 * provided trajectory.
+	 *
+	 * @param trajectory         The trajectory to follow.
+	 * @param pose               A function that returns the robot pose - use one of the odometry classes to provide this.
+	 * @param kinematics         The kinematics for the robot drivetrain.
+	 * @param xController        The Trajectory Tracker PID controller for the robot's x position.
+	 * @param yController        The Trajectory Tracker PID controller for the robot's y position.
+	 * @param rotationController The Trajectory Tracker PID controller for angle for the robot.
+	 * @param output             The raw output module states from the position controllers.
+	 * @param requirements       The subsystems to require.
+	 * @param useAllianceColor Should the path states be automatically transformed based on alliance
+	 *     color? In order for this to work properly, you MUST create your path on the blue side of
+	 *     the field.
 	 */
 	PPSwerveControllerCommand(PathPlannerTrajectory trajectory,
 			std::function<frc::Pose2d()> pose,
@@ -54,7 +85,33 @@ public:
 			frc2::PIDController xController, frc2::PIDController yController,
 			frc2::PIDController rotationController,
 			std::function<void(std::array<frc::SwerveModuleState, 4>)> output,
-			std::span<frc2::Subsystem* const > requirements = { });
+			std::initializer_list<frc2::Subsystem*> requirements,
+			bool useAllianceColor = true);
+
+	/**
+	 * @brief Constructs a new PPSwerveControllerCommand that when executed will follow the
+	 * provided trajectory.
+	 *
+	 * @param trajectory         The trajectory to follow.
+	 * @param pose               A function that returns the robot pose - use one of the odometry classes to provide this.
+	 * @param kinematics         The kinematics for the robot drivetrain.
+	 * @param xController        The Trajectory Tracker PID controller for the robot's x position.
+	 * @param yController        The Trajectory Tracker PID controller for the robot's y position.
+	 * @param rotationController The Trajectory Tracker PID controller for angle for the robot.
+	 * @param output             The raw output module states from the position controllers.
+	 * @param requirements       The subsystems to require.
+	 * @param useAllianceColor Should the path states be automatically transformed based on alliance
+	 *     color? In order for this to work properly, you MUST create your path on the blue side of
+	 *     the field.
+	 */
+	PPSwerveControllerCommand(PathPlannerTrajectory trajectory,
+			std::function<frc::Pose2d()> pose,
+			frc::SwerveDriveKinematics<4> kinematics,
+			frc2::PIDController xController, frc2::PIDController yController,
+			frc2::PIDController rotationController,
+			std::function<void(std::array<frc::SwerveModuleState, 4>)> output,
+			std::span<frc2::Subsystem* const > requirements = { },
+			bool useAllianceColor = true);
 
 	void Initialize() override;
 
@@ -75,5 +132,7 @@ private:
 	frc::Timer m_timer;
 	PPHolonomicDriveController m_controller;
 	frc::Field2d m_field;
+
+	bool m_useAllianceColor;
 };
 }


### PR DESCRIPTION
PPLib path following commands will automatically transform path states for the current alliance color. In order for this to work properly, paths created in the GUI MUST be made on the blue side of the field.

This will not transform any states if the path was generated on-the-fly since those should be made in the correct coordinate system already.

If not using PPLib commands, you will need to use the transformStateForAlliance method manually to transform the path states.