### PR TITLE
Fix drivetrain type initialization

### DIFF
--- a/pathplannerlib/src/main/native/cpp/pathplanner/lib/auto/BaseAutoBuilder.cpp
+++ b/pathplannerlib/src/main/native/cpp/pathplanner/lib/auto/BaseAutoBuilder.cpp
@@ -11,7 +11,7 @@ BaseAutoBuilder::BaseAutoBuilder(std::function<frc::Pose2d()> pose,
 		std::unordered_map<std::string, std::shared_ptr<frc2::Command>> eventMap,
 		DriveTrainType drivetrainType, bool useAllianceColor) : m_pose(
 		std::move(pose)), m_resetPose(std::move(resetPose)), m_eventMap(
-		eventMap), m_useAllianceColor(useAllianceColor) {
+		eventMap), m_useAllianceColor(useAllianceColor), m_drivetrainType(drivetrainType) {
 }
 
 frc2::CommandPtr BaseAutoBuilder::followPathGroup(

--- a/pathplannerlib/src/main/native/cpp/pathplanner/lib/auto/BaseAutoBuilder.cpp
+++ b/pathplannerlib/src/main/native/cpp/pathplanner/lib/auto/BaseAutoBuilder.cpp
@@ -11,7 +11,8 @@ BaseAutoBuilder::BaseAutoBuilder(std::function<frc::Pose2d()> pose,
 		std::unordered_map<std::string, std::shared_ptr<frc2::Command>> eventMap,
 		DriveTrainType drivetrainType, bool useAllianceColor) : m_pose(
 		std::move(pose)), m_resetPose(std::move(resetPose)), m_eventMap(
-		eventMap), m_useAllianceColor(useAllianceColor), m_drivetrainType(drivetrainType) {
+		eventMap), m_drivetrainType(drivetrainType), m_useAllianceColor(
+		useAllianceColor) {
 }
 
 frc2::CommandPtr BaseAutoBuilder::followPathGroup(


### PR DESCRIPTION
Add initialization of drivetrain type to `BaseAutoBuilder` that a lack of had previously created issues for differential drive paths starting at non zero rotations