### PR TITLE
Add Focused Selection Option

### DIFF
--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -47,6 +47,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
   RobotPath? _currentPath;
   Size _robotSize = const Size(0.75, 1.0);
   bool _holonomicMode = false;
+  bool _focusedSelection = false;
   bool _generateJSON = false;
   bool _generateCSV = false;
   bool _pplibClient = false;
@@ -493,6 +494,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
               robotSize: _robotSize,
               holonomicMode: _holonomicMode,
               showGeneratorSettings: _generateJSON || _generateCSV,
+              focusedSelection: _focusedSelection,
               savePath: (path) => _savePath(path),
               prefs: widget.prefs,
             ),
@@ -626,6 +628,7 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
         widget.prefs.getDouble('robotLength') ?? 1.0,
       );
       _holonomicMode = widget.prefs.getBool('holonomicMode') ?? false;
+      _focusedSelection = widget.prefs.getBool('focusedSelection') ?? false;
       _generateJSON = widget.prefs.getBool('generateJSON') ?? false;
       _generateCSV = widget.prefs.getBool('generateCSV') ?? false;
       _pplibClient = widget.prefs.getBool('pplibClient') ?? false;

--- a/lib/widgets/dialogs/settings_dialog.dart
+++ b/lib/widgets/dialogs/settings_dialog.dart
@@ -39,6 +39,7 @@ class _SettingsDialogState extends State<SettingsDialog> {
   late double _width;
   late double _length;
   late bool _holonomicMode;
+  late bool _focusedSelection;
   late bool _generateJSON;
   late bool _generateCSV;
   late bool _pplibClient;
@@ -54,6 +55,7 @@ class _SettingsDialogState extends State<SettingsDialog> {
     _width = widget.prefs.getDouble('robotWidth') ?? 0.75;
     _length = widget.prefs.getDouble('robotLength') ?? 1.0;
     _holonomicMode = widget.prefs.getBool('holonomicMode') ?? false;
+    _focusedSelection = widget.prefs.getBool('focusedSelection') ?? false;
     _generateJSON = widget.prefs.getBool('generateJSON') ?? false;
     _generateCSV = widget.prefs.getBool('generateCSV') ?? false;
     _pplibClient = widget.prefs.getBool('pplibClient') ?? false;
@@ -253,6 +255,30 @@ class _SettingsDialogState extends State<SettingsDialog> {
                         widget.prefs.setBool('holonomicMode', value);
                         setState(() {
                           _holonomicMode = value;
+                        });
+                        widget.onSettingsChanged();
+                      },
+                    ),
+                    FilterChip(
+                      label: const Text('Focused Selection'),
+                      labelStyle: TextStyle(
+                          color: _focusedSelection
+                              ? colorScheme.onPrimaryContainer
+                              : colorScheme.onSurface),
+                      selected: _focusedSelection,
+                      backgroundColor: colorScheme.surface,
+                      selectedColor: colorScheme.primaryContainer,
+                      shape: RoundedRectangleBorder(
+                          borderRadius: BorderRadius.circular(8),
+                          side: BorderSide(
+                              color: _focusedSelection
+                                  ? colorScheme.primaryContainer
+                                  : colorScheme.outline,
+                              width: 1)),
+                      onSelected: (value) {
+                        widget.prefs.setBool('focusedSelection', value);
+                        setState(() {
+                          _focusedSelection = value;
                         });
                         widget.onSettingsChanged();
                       },

--- a/lib/widgets/path_editor/cards/waypoint_card.dart
+++ b/lib/widgets/path_editor/cards/waypoint_card.dart
@@ -14,6 +14,8 @@ class WaypointCard extends StatefulWidget {
   final bool deleteEnabled;
   final VoidCallback onDelete;
   final VoidCallback onShouldSave;
+  final VoidCallback? onPrevWaypoint;
+  final VoidCallback? onNextWaypoint;
   final GlobalKey stackKey;
   final SharedPreferences prefs;
 
@@ -26,6 +28,8 @@ class WaypointCard extends StatefulWidget {
       required this.onDelete,
       required this.onShouldSave,
       required this.prefs,
+      this.onPrevWaypoint,
+      this.onNextWaypoint,
       super.key});
 
   @override
@@ -117,9 +121,25 @@ class _WaypointCardState extends State<WaypointCard> {
             ),
           ),
         ),
+        IconButton(
+          onPressed: widget.onPrevWaypoint,
+          icon: const Icon(Icons.arrow_left),
+          iconSize: 20,
+          splashRadius: 20,
+          padding: const EdgeInsets.all(0),
+          tooltip: 'Previous Waypoint',
+        ),
         Text(
-          widget.label ?? 'Waypoint Label',
+          widget.label ?? 'Edit Waypoint',
           style: TextStyle(color: colorScheme.onSurface),
+        ),
+        IconButton(
+          onPressed: widget.onNextWaypoint,
+          icon: const Icon(Icons.arrow_right),
+          iconSize: 20,
+          splashRadius: 20,
+          padding: const EdgeInsets.all(0),
+          tooltip: 'Next Waypoint',
         ),
         SizedBox(
           height: 30,

--- a/lib/widgets/path_editor/editors/edit_editor.dart
+++ b/lib/widgets/path_editor/editors/edit_editor.dart
@@ -125,8 +125,7 @@ class _EditEditorState extends State<EditEditor> {
                       Point(_xPixelsToMeters(details.localPosition.dx),
                           _yPixelsToMeters(details.localPosition.dy)),
                       _selectedPointIndex == -1 ||
-                              _selectedPointIndex >=
-                                  waypoints.length
+                              _selectedPointIndex >= waypoints.length
                           ? waypoints.length - 1
                           : _selectedPointIndex);
                   widget.savePath(widget.path);
@@ -283,13 +282,12 @@ class _EditEditorState extends State<EditEditor> {
                 Positioned.fill(
                   child: CustomPaint(
                     painter: _EditPainter(
-                      widget.path,
-                      widget.fieldImage,
-                      widget.robotSize,
-                      widget.holonomicMode,
-                      _selectedWaypoint,
-                      widget.focusedSelection
-                    ),
+                        widget.path,
+                        widget.fieldImage,
+                        widget.robotSize,
+                        widget.holonomicMode,
+                        _selectedWaypoint,
+                        widget.focusedSelection),
                   ),
                 ),
               ],
@@ -318,7 +316,8 @@ class _EditEditorState extends State<EditEditor> {
       onShouldSave: () {
         widget.savePath(widget.path);
       },
-      onNextWaypoint: _selectedPointIndex < waypoints.length - 1 ? nextWaypoint : null,
+      onNextWaypoint:
+          _selectedPointIndex < waypoints.length - 1 ? nextWaypoint : null,
       onPrevWaypoint: _selectedPointIndex > 0 ? previousWaypoint : null,
     );
   }
@@ -357,14 +356,10 @@ class _EditEditorState extends State<EditEditor> {
         setState(() {
           Waypoint w = waypoints.removeAt(delIndex);
           if (w.isEndPoint()) {
-            waypoints[waypoints.length - 1]
-                .nextControl = null;
-            waypoints[waypoints.length - 1].isReversal =
-                false;
-            waypoints[waypoints.length - 1]
-                .isStopPoint = false;
-            waypoints[waypoints.length - 1]
-                .holonomicAngle ??= 0;
+            waypoints[waypoints.length - 1].nextControl = null;
+            waypoints[waypoints.length - 1].isReversal = false;
+            waypoints[waypoints.length - 1].isStopPoint = false;
+            waypoints[waypoints.length - 1].holonomicAngle ??= 0;
           } else if (w.isStartPoint()) {
             waypoints[0].prevControl = null;
             waypoints[0].isReversal = false;
@@ -435,10 +430,14 @@ class _EditPainter extends CustomPainter {
 
     if (holonomicMode) {
       PathPainterUtil.paintCenterPath(
-          path, canvas, scale, Colors.grey[300]!, fieldImage);
+          path, canvas, scale, Colors.grey[300]!, fieldImage,
+          selectedWaypoint: selectedWaypoint,
+          focusedSelection: focusedSelection);
     } else {
       PathPainterUtil.paintDualPaths(
-          path, robotSize, canvas, scale, Colors.grey[300]!, fieldImage);
+          path, robotSize, canvas, scale, Colors.grey[300]!, fieldImage,
+          selectedWaypoint: selectedWaypoint,
+          focusedSelection: focusedSelection);
     }
 
     int waypointsMinIndex = 0;
@@ -450,7 +449,8 @@ class _EditPainter extends CustomPainter {
       waypointsMaxIndex = min(selectedIndex + 2, waypointsMaxIndex);
     }
 
-    for (Waypoint w in path.waypoints.sublist(waypointsMinIndex, waypointsMaxIndex)) {
+    for (Waypoint w
+        in path.waypoints.sublist(waypointsMinIndex, waypointsMaxIndex)) {
       Color color = Colors.grey[300]!;
 
       if (w.isStopPoint) {

--- a/lib/widgets/path_editor/editors/edit_editor.dart
+++ b/lib/widgets/path_editor/editors/edit_editor.dart
@@ -18,6 +18,7 @@ class EditEditor extends StatefulWidget {
   final RobotPath path;
   final Size robotSize;
   final bool holonomicMode;
+  final bool focusedSelection;
   final FieldImage fieldImage;
   final void Function(RobotPath path) savePath;
   final bool showGeneratorSettings;
@@ -30,6 +31,7 @@ class EditEditor extends StatefulWidget {
       required this.fieldImage,
       required this.savePath,
       this.showGeneratorSettings = false,
+      this.focusedSelection = false,
       required this.prefs,
       super.key});
 
@@ -43,6 +45,8 @@ class _EditEditorState extends State<EditEditor> {
   int _selectedPointIndex = -1;
   Waypoint? _dragOldValue;
   final GlobalKey _key = GlobalKey();
+
+  List<Waypoint> get waypoints => widget.path.waypoints;
 
   @override
   void initState() {
@@ -59,9 +63,7 @@ class _EditEditorState extends State<EditEditor> {
         LogicalKeyboardKey.keyZ
       },
       onKeysPressed: () {
-        setState(() {
-          _selectedWaypoint = null;
-        });
+        deselectWaypoint();
         UndoRedo.undo();
       },
       child: KeyBoardShortcuts(
@@ -72,24 +74,38 @@ class _EditEditorState extends State<EditEditor> {
           LogicalKeyboardKey.keyY
         },
         onKeysPressed: () {
-          setState(() {
-            _selectedWaypoint = null;
-          });
+          deselectWaypoint();
           UndoRedo.redo();
         },
-        child: Stack(
-          key: _key,
-          children: [
-            _buildEditor(),
-            _buildWaypointCard(),
-            _buildGeneratorSettingsCard(),
-          ],
+        child: KeyBoardShortcuts(
+          keysToPress: {LogicalKeyboardKey.control, LogicalKeyboardKey.delete},
+          onKeysPressed: () {
+            if (_selectedWaypoint != null) {
+              removeWaypoint(_selectedWaypoint!);
+            }
+          },
+          child: Stack(
+            key: _key,
+            children: [
+              _buildEditor(),
+              _buildWaypointCard(),
+              _buildGeneratorSettingsCard(),
+            ],
+          ),
         ),
       ),
     );
   }
 
   Widget _buildEditor() {
+    int waypointsMinIndex = 0;
+    int waypointsMaxIndex = waypoints.length;
+
+    if (widget.focusedSelection && _selectedWaypoint != null) {
+      waypointsMinIndex = max(0, _selectedPointIndex - 1);
+      waypointsMaxIndex = min(_selectedPointIndex + 2, waypointsMaxIndex);
+    }
+
     return Center(
       child: InteractiveViewer(
         child: GestureDetector(
@@ -97,10 +113,10 @@ class _EditEditorState extends State<EditEditor> {
           onDoubleTapDown: (details) {
             UndoRedo.addChange(Change(
               [
-                RobotPath.cloneWaypointList(widget.path.waypoints),
+                RobotPath.cloneWaypointList(waypoints),
                 _selectedPointIndex == -1 ||
-                        _selectedPointIndex >= widget.path.waypoints.length
-                    ? widget.path.waypoints.length - 1
+                        _selectedPointIndex >= waypoints.length
+                    ? waypoints.length - 1
                     : _selectedPointIndex
               ],
               () {
@@ -110,8 +126,8 @@ class _EditEditorState extends State<EditEditor> {
                           _yPixelsToMeters(details.localPosition.dy)),
                       _selectedPointIndex == -1 ||
                               _selectedPointIndex >=
-                                  widget.path.waypoints.length
-                          ? widget.path.waypoints.length - 1
+                                  waypoints.length
+                          ? waypoints.length - 1
                           : _selectedPointIndex);
                   widget.savePath(widget.path);
                 });
@@ -119,13 +135,13 @@ class _EditEditorState extends State<EditEditor> {
               (oldValue) {
                 setState(() {
                   if (oldValue[1] == oldValue[0].length - 1) {
-                    widget.path.waypoints.removeLast();
-                    widget.path.waypoints.last.nextControl = null;
+                    waypoints.removeLast();
+                    waypoints.last.nextControl = null;
                   } else {
-                    widget.path.waypoints.removeAt(oldValue[1] + 1);
-                    widget.path.waypoints[oldValue[1]].nextControl =
+                    waypoints.removeAt(oldValue[1] + 1);
+                    waypoints[oldValue[1]].nextControl =
                         oldValue[0][oldValue[1]].nextControl;
-                    widget.path.waypoints[oldValue[1] + 1].prevControl =
+                    waypoints[oldValue[1] + 1].prevControl =
                         oldValue[0][oldValue[1] + 1].prevControl;
                   }
                   _selectedPointIndex = -1;
@@ -134,8 +150,8 @@ class _EditEditorState extends State<EditEditor> {
               },
             ));
             setState(() {
-              for (var i = 0; i < widget.path.waypoints.length; i++) {
-                Waypoint w = widget.path.waypoints[i];
+              for (var i = waypointsMinIndex; i < waypointsMaxIndex; i++) {
+                Waypoint w = waypoints[i];
                 if (w.isPointInAnchor(
                         _xPixelsToMeters(details.localPosition.dx),
                         _yPixelsToMeters(details.localPosition.dy),
@@ -157,10 +173,7 @@ class _EditEditorState extends State<EditEditor> {
                         _pixelsToMeters(PathPainterUtil.uiPointSizeToPixels(
                             15, _EditPainter.scale, widget.fieldImage)),
                         widget.robotSize.height)) {
-                  setState(() {
-                    _selectedWaypoint = w;
-                    _selectedPointIndex = i;
-                  });
+                  setSelectedWaypointIndex(i);
                 }
               }
             });
@@ -171,8 +184,8 @@ class _EditEditorState extends State<EditEditor> {
             if (!currentScope.hasPrimaryFocus && currentScope.hasFocus) {
               FocusManager.instance.primaryFocus!.unfocus();
             }
-            for (var i = 0; i < widget.path.waypoints.length; i++) {
-              Waypoint w = widget.path.waypoints[i];
+            for (var i = waypointsMinIndex; i < waypointsMaxIndex; i++) {
+              Waypoint w = waypoints[i];
               if (w.isPointInAnchor(
                       _xPixelsToMeters(details.localPosition.dx),
                       _yPixelsToMeters(details.localPosition.dy),
@@ -194,20 +207,15 @@ class _EditEditorState extends State<EditEditor> {
                       _pixelsToMeters(PathPainterUtil.uiPointSizeToPixels(
                           15, _EditPainter.scale, widget.fieldImage)),
                       widget.robotSize.height)) {
-                setState(() {
-                  _selectedWaypoint = w;
-                  _selectedPointIndex = i;
-                });
+                setSelectedWaypointIndex(i);
                 return;
               }
             }
-            setState(() {
-              _selectedWaypoint = null;
-              _selectedPointIndex = -1;
-            });
+            deselectWaypoint();
           },
           onPanStart: (details) {
-            for (Waypoint w in widget.path.waypoints.reversed) {
+            for (int i = waypointsMaxIndex - 2; i >= waypointsMinIndex; i--) {
+              Waypoint w = waypoints[i];
               if (w.startDragging(
                   _xPixelsToMeters(details.localPosition.dx),
                   _yPixelsToMeters(details.localPosition.dy),
@@ -245,21 +253,21 @@ class _EditEditorState extends State<EditEditor> {
           onPanEnd: (details) {
             if (_draggedPoint != null) {
               _draggedPoint!.stopDragging();
-              int index = widget.path.waypoints.indexOf(_draggedPoint!);
+              int index = waypoints.indexOf(_draggedPoint!);
               Waypoint dragEnd = _draggedPoint!.clone();
               UndoRedo.addChange(Change(
                 _dragOldValue,
                 () {
                   setState(() {
-                    if (widget.path.waypoints[index] != _draggedPoint) {
-                      widget.path.waypoints[index] = dragEnd.clone();
+                    if (waypoints[index] != _draggedPoint) {
+                      waypoints[index] = dragEnd.clone();
                     }
                     widget.savePath(widget.path);
                   });
                 },
                 (oldValue) {
                   setState(() {
-                    widget.path.waypoints[index] = oldValue.clone();
+                    waypoints[index] = oldValue.clone();
                     widget.savePath(widget.path);
                   });
                 },
@@ -280,6 +288,7 @@ class _EditEditorState extends State<EditEditor> {
                       widget.robotSize,
                       widget.holonomicMode,
                       _selectedWaypoint,
+                      widget.focusedSelection
                     ),
                   ),
                 ),
@@ -295,10 +304,7 @@ class _EditEditorState extends State<EditEditor> {
     String? waypointLabel = widget.path.getWaypointLabel(_selectedWaypoint);
     if (waypointLabel == null) {
       // Somehow the selected waypoint is not in the path. Reset selected point.
-      setState(() {
-        _selectedPointIndex = -1;
-        _selectedWaypoint = null;
-      });
+      deselectWaypoint();
     }
 
     return WaypointCard(
@@ -306,49 +312,77 @@ class _EditEditorState extends State<EditEditor> {
       stackKey: _key,
       label: waypointLabel,
       holonomicEnabled: widget.holonomicMode,
-      deleteEnabled: widget.path.waypoints.length > 2,
+      deleteEnabled: waypoints.length > 2,
       prefs: widget.prefs,
-      onDelete: () {
-        int delIndex = widget.path.waypoints.indexOf(_selectedWaypoint!);
-        UndoRedo.addChange(Change(
-          RobotPath.cloneWaypointList(widget.path.waypoints),
-          () {
-            setState(() {
-              Waypoint w = widget.path.waypoints.removeAt(delIndex);
-              if (w.isEndPoint()) {
-                widget.path.waypoints[widget.path.waypoints.length - 1]
-                    .nextControl = null;
-                widget.path.waypoints[widget.path.waypoints.length - 1]
-                    .isReversal = false;
-                widget.path.waypoints[widget.path.waypoints.length - 1]
-                    .isStopPoint = false;
-                widget.path.waypoints[widget.path.waypoints.length - 1]
-                    .holonomicAngle ??= 0;
-              } else if (w.isStartPoint()) {
-                widget.path.waypoints[0].prevControl = null;
-                widget.path.waypoints[0].isReversal = false;
-                widget.path.waypoints[0].isStopPoint = false;
-                widget.path.waypoints[0].holonomicAngle ??= 0;
-              }
-
-              widget.savePath(widget.path);
-            });
-          },
-          (oldValue) {
-            setState(() {
-              widget.path.waypoints = RobotPath.cloneWaypointList(oldValue);
-              widget.savePath(widget.path);
-            });
-          },
-        ));
-        setState(() {
-          _selectedWaypoint = null;
-        });
-      },
+      onDelete: () => removeWaypoint(_selectedWaypoint!),
       onShouldSave: () {
         widget.savePath(widget.path);
       },
+      onNextWaypoint: _selectedPointIndex < waypoints.length - 1 ? nextWaypoint : null,
+      onPrevWaypoint: _selectedPointIndex > 0 ? previousWaypoint : null,
     );
+  }
+
+  void previousWaypoint() {
+    setSelectedWaypointIndex(_selectedPointIndex - 1);
+  }
+
+  void nextWaypoint() {
+    setSelectedWaypointIndex(_selectedPointIndex + 1);
+  }
+
+  void setSelectedWaypointIndex(int index) {
+    if (waypoints.isEmpty) {
+      return deselectWaypoint();
+    }
+
+    setState(() {
+      _selectedPointIndex = index.clamp(0, waypoints.length - 1);
+      _selectedWaypoint = waypoints[_selectedPointIndex];
+    });
+  }
+
+  void deselectWaypoint() {
+    setState(() {
+      _selectedPointIndex = -1;
+      _selectedWaypoint = null;
+    });
+  }
+
+  void removeWaypoint(Waypoint waypoint) {
+    int delIndex = waypoints.indexOf(waypoint);
+    UndoRedo.addChange(Change(
+      RobotPath.cloneWaypointList(waypoints),
+      () {
+        setState(() {
+          Waypoint w = waypoints.removeAt(delIndex);
+          if (w.isEndPoint()) {
+            waypoints[waypoints.length - 1]
+                .nextControl = null;
+            waypoints[waypoints.length - 1].isReversal =
+                false;
+            waypoints[waypoints.length - 1]
+                .isStopPoint = false;
+            waypoints[waypoints.length - 1]
+                .holonomicAngle ??= 0;
+          } else if (w.isStartPoint()) {
+            waypoints[0].prevControl = null;
+            waypoints[0].isReversal = false;
+            waypoints[0].isStopPoint = false;
+            waypoints[0].holonomicAngle ??= 0;
+          }
+
+          widget.savePath(widget.path);
+        });
+      },
+      (oldValue) {
+        setState(() {
+          widget.path.waypoints = RobotPath.cloneWaypointList(oldValue);
+          widget.savePath(widget.path);
+        });
+      },
+    ));
+    deselectWaypoint();
   }
 
   Widget _buildGeneratorSettingsCard() {
@@ -387,12 +421,13 @@ class _EditPainter extends CustomPainter {
   final FieldImage fieldImage;
   final Size robotSize;
   final bool holonomicMode;
+  final bool focusedSelection;
   final Waypoint? selectedWaypoint;
 
   static double scale = 1;
 
   _EditPainter(this.path, this.fieldImage, this.robotSize, this.holonomicMode,
-      this.selectedWaypoint);
+      this.selectedWaypoint, this.focusedSelection);
 
   @override
   void paint(Canvas canvas, Size size) {
@@ -406,7 +441,16 @@ class _EditPainter extends CustomPainter {
           path, robotSize, canvas, scale, Colors.grey[300]!, fieldImage);
     }
 
-    for (Waypoint w in path.waypoints) {
+    int waypointsMinIndex = 0;
+    int waypointsMaxIndex = path.waypoints.length;
+
+    if (focusedSelection && selectedWaypoint != null) {
+      int selectedIndex = path.waypoints.indexOf(selectedWaypoint!);
+      waypointsMinIndex = max(0, selectedIndex - 1);
+      waypointsMaxIndex = min(selectedIndex + 2, waypointsMaxIndex);
+    }
+
+    for (Waypoint w in path.waypoints.sublist(waypointsMinIndex, waypointsMaxIndex)) {
       Color color = Colors.grey[300]!;
 
       if (w.isStopPoint) {

--- a/lib/widgets/path_editor/path_editor.dart
+++ b/lib/widgets/path_editor/path_editor.dart
@@ -27,6 +27,7 @@ class PathEditor extends StatefulWidget {
   final RobotPath path;
   final Size robotSize;
   final bool holonomicMode;
+  final bool focusedSelection;
   final FieldImage fieldImage;
   final bool showGeneratorSettings;
   final void Function(RobotPath path) savePath;
@@ -38,6 +39,7 @@ class PathEditor extends StatefulWidget {
       required this.robotSize,
       required this.holonomicMode,
       this.showGeneratorSettings = false,
+      this.focusedSelection = false,
       required this.savePath,
       required this.prefs,
       super.key});
@@ -104,6 +106,7 @@ class _PathEditorState extends State<PathEditor> {
           holonomicMode: widget.holonomicMode,
           fieldImage: widget.fieldImage,
           showGeneratorSettings: widget.showGeneratorSettings,
+          focusedSelection: widget.focusedSelection,
           savePath: widget.savePath,
           prefs: widget.prefs,
           key: ValueKey(widget.path),

--- a/lib/widgets/path_editor/path_painter_util.dart
+++ b/lib/widgets/path_editor/path_painter_util.dart
@@ -7,20 +7,20 @@ import 'package:pathplanner/services/generator/geometry_util.dart';
 import 'package:pathplanner/widgets/field_image.dart';
 
 class PathPainterUtil {
-  static void paintCenterPath(RobotPath path, Canvas canvas,
-      double scale, Color color, FieldImage fieldImage,
+  static void paintCenterPath(RobotPath path, Canvas canvas, double scale,
+      Color color, FieldImage fieldImage,
       {Waypoint? selectedWaypoint, bool? focusedSelection}) {
     var paint = Paint()
       ..style = PaintingStyle.stroke
       ..color = color
       ..strokeWidth = 2;
 
-
     for (int i = 0; i < path.waypoints.length - 1; i++) {
       if ((focusedSelection ?? false) && selectedWaypoint != null) {
         int index = path.waypoints.indexOf(selectedWaypoint);
         int difference = index - i;
-        paint.color = 0 <= difference && difference <= 1 ? color : color.withAlpha(20);
+        paint.color =
+            0 <= difference && difference <= 1 ? color : color.withAlpha(20);
       } else {
         paint.color = color;
       }
@@ -29,10 +29,10 @@ class PathPainterUtil {
           pointToPixelOffset(path.waypoints[i].anchorPoint, scale, fieldImage);
       Offset p1 =
           pointToPixelOffset(path.waypoints[i].nextControl!, scale, fieldImage);
-      Offset p2 =
-          pointToPixelOffset(path.waypoints[i + 1].prevControl!, scale, fieldImage);
-      Offset p3 =
-          pointToPixelOffset(path.waypoints[i + 1].anchorPoint, scale, fieldImage);
+      Offset p2 = pointToPixelOffset(
+          path.waypoints[i + 1].prevControl!, scale, fieldImage);
+      Offset p3 = pointToPixelOffset(
+          path.waypoints[i + 1].anchorPoint, scale, fieldImage);
       p.moveTo(p0.dx, p0.dy);
       p.cubicTo(p1.dx, p1.dy, p2.dx, p2.dy, p3.dx, p3.dy);
 
@@ -40,8 +40,8 @@ class PathPainterUtil {
     }
   }
 
-  static void paintDualPaths(RobotPath path, Size robotSize,
-      Canvas canvas, double scale, Color color, FieldImage fieldImage,
+  static void paintDualPaths(RobotPath path, Size robotSize, Canvas canvas,
+      double scale, Color color, FieldImage fieldImage,
       {Waypoint? selectedWaypoint, bool? focusedSelection}) {
     var paint = Paint()
       ..style = PaintingStyle.stroke
@@ -52,7 +52,8 @@ class PathPainterUtil {
       if ((focusedSelection ?? false) && selectedWaypoint != null) {
         int index = path.waypoints.indexOf(selectedWaypoint);
         int difference = index - i;
-        paint.color = 0 <= difference && difference <= 1 ? color : color.withAlpha(20);
+        paint.color =
+            0 <= difference && difference <= 1 ? color : color.withAlpha(20);
       } else {
         paint.color = color;
       }
@@ -64,10 +65,10 @@ class PathPainterUtil {
           pointToPixelOffset(path.waypoints[i].anchorPoint, scale, fieldImage);
       Offset p1 =
           pointToPixelOffset(path.waypoints[i].nextControl!, scale, fieldImage);
-      Offset p2 =
-          pointToPixelOffset(path.waypoints[i + 1].prevControl!, scale, fieldImage);
-      Offset p3 =
-          pointToPixelOffset(path.waypoints[i + 1].anchorPoint, scale, fieldImage);
+      Offset p2 = pointToPixelOffset(
+          path.waypoints[i + 1].prevControl!, scale, fieldImage);
+      Offset p3 = pointToPixelOffset(
+          path.waypoints[i + 1].anchorPoint, scale, fieldImage);
 
       for (double t = 0; t < 1.0; t += 0.01) {
         Offset center = cubicLerp(p0, p1, p2, p3, t);

--- a/lib/widgets/path_editor/path_painter_util.dart
+++ b/lib/widgets/path_editor/path_painter_util.dart
@@ -7,23 +7,32 @@ import 'package:pathplanner/services/generator/geometry_util.dart';
 import 'package:pathplanner/widgets/field_image.dart';
 
 class PathPainterUtil {
-  static void paintCenterPath(RobotPath path, Canvas canvas, double scale,
-      Color color, FieldImage fieldImage) {
+  static void paintCenterPath(RobotPath path, Canvas canvas,
+      double scale, Color color, FieldImage fieldImage,
+      {Waypoint? selectedWaypoint, bool? focusedSelection}) {
     var paint = Paint()
       ..style = PaintingStyle.stroke
       ..color = color
       ..strokeWidth = 2;
 
+
     for (int i = 0; i < path.waypoints.length - 1; i++) {
+      if ((focusedSelection ?? false) && selectedWaypoint != null) {
+        int index = path.waypoints.indexOf(selectedWaypoint);
+        int difference = index - i;
+        paint.color = 0 <= difference && difference <= 1 ? color : color.withAlpha(20);
+      } else {
+        paint.color = color;
+      }
       Path p = Path();
       Offset p0 =
           pointToPixelOffset(path.waypoints[i].anchorPoint, scale, fieldImage);
       Offset p1 =
           pointToPixelOffset(path.waypoints[i].nextControl!, scale, fieldImage);
-      Offset p2 = pointToPixelOffset(
-          path.waypoints[i + 1].prevControl!, scale, fieldImage);
-      Offset p3 = pointToPixelOffset(
-          path.waypoints[i + 1].anchorPoint, scale, fieldImage);
+      Offset p2 =
+          pointToPixelOffset(path.waypoints[i + 1].prevControl!, scale, fieldImage);
+      Offset p3 =
+          pointToPixelOffset(path.waypoints[i + 1].anchorPoint, scale, fieldImage);
       p.moveTo(p0.dx, p0.dy);
       p.cubicTo(p1.dx, p1.dy, p2.dx, p2.dy, p3.dx, p3.dy);
 
@@ -31,14 +40,22 @@ class PathPainterUtil {
     }
   }
 
-  static void paintDualPaths(RobotPath path, Size robotSize, Canvas canvas,
-      double scale, Color color, FieldImage fieldImage) {
+  static void paintDualPaths(RobotPath path, Size robotSize,
+      Canvas canvas, double scale, Color color, FieldImage fieldImage,
+      {Waypoint? selectedWaypoint, bool? focusedSelection}) {
     var paint = Paint()
       ..style = PaintingStyle.stroke
       ..color = color
       ..strokeWidth = 2;
 
     for (int i = 0; i < path.waypoints.length - 1; i++) {
+      if ((focusedSelection ?? false) && selectedWaypoint != null) {
+        int index = path.waypoints.indexOf(selectedWaypoint);
+        int difference = index - i;
+        paint.color = 0 <= difference && difference <= 1 ? color : color.withAlpha(20);
+      } else {
+        paint.color = color;
+      }
       Path p = Path();
 
       double halfWidth = metersToPixels(robotSize.width / 2, scale, fieldImage);
@@ -47,10 +64,10 @@ class PathPainterUtil {
           pointToPixelOffset(path.waypoints[i].anchorPoint, scale, fieldImage);
       Offset p1 =
           pointToPixelOffset(path.waypoints[i].nextControl!, scale, fieldImage);
-      Offset p2 = pointToPixelOffset(
-          path.waypoints[i + 1].prevControl!, scale, fieldImage);
-      Offset p3 = pointToPixelOffset(
-          path.waypoints[i + 1].anchorPoint, scale, fieldImage);
+      Offset p2 =
+          pointToPixelOffset(path.waypoints[i + 1].prevControl!, scale, fieldImage);
+      Offset p3 =
+          pointToPixelOffset(path.waypoints[i + 1].anchorPoint, scale, fieldImage);
 
       for (double t = 0; t < 1.0; t += 0.01) {
         Offset center = cubicLerp(p0, p1, p2, p3, t);


### PR DESCRIPTION
Closes #245 
Closes #248 

### Description
Adds an option to hide all waypoints that aren't directly connected to the selected waypoint. I still think there is work to be done here, and would appreciate feedback from others to make this as nice a feature as possible. 

### With focused selection disabled:
![image](https://user-images.githubusercontent.com/37554439/218317013-895ca6b4-d3b0-4687-a1f3-d74975404d2a.png)

### With focused selection enabled:
![image](https://user-images.githubusercontent.com/37554439/218316986-c14a8b5c-bd41-4765-8012-eed79c4b2687.png)

### New setting:
![image](https://user-images.githubusercontent.com/37554439/218316348-826b80a9-4f3b-4c5d-9a87-86437e440365.png)
