### PR TITLE
Refactor rotational transformation for red alliance

### DIFF
--- a/pathplannerlib/src/main/java/com/pathplanner/lib/PathPlannerTrajectory.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/PathPlannerTrajectory.java
@@ -122,8 +122,8 @@ public class PathPlannerTrajectory extends Trajectory {
 
       Translation2d transformedTranslation =
           new Translation2d(state.poseMeters.getX(), FIELD_WIDTH_METERS - state.poseMeters.getY());
-      Rotation2d transformedHeading = state.poseMeters.getRotation().times(-1);
-      Rotation2d transformedHolonomicRotation = state.holonomicRotation.times(-1);
+      Rotation2d transformedHeading = state.poseMeters.getRotation().plus(Rotation2d.fromRadians(Math.PI);
+      Rotation2d transformedHolonomicRotation = state.holonomicRotation.plus(Rotation2d.fromRadians(Math.PI);
 
       transformedState.timeSeconds = state.timeSeconds;
       transformedState.velocityMetersPerSecond = state.velocityMetersPerSecond;

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/PathPlannerTrajectory.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/PathPlannerTrajectory.java
@@ -11,7 +11,7 @@ import java.util.Comparator;
 import java.util.List;
 
 public class PathPlannerTrajectory extends Trajectory {
-  private static final double FIELD_WIDTH_METERS = 8.02;
+  private static final double FIELD_WIDTH_METERS = 16.53;
 
   private final List<EventMarker> markers;
   private final StopEvent startStopEvent;
@@ -121,7 +121,7 @@ public class PathPlannerTrajectory extends Trajectory {
       PathPlannerState transformedState = new PathPlannerState();
 
       Translation2d transformedTranslation =
-          new Translation2d(state.poseMeters.getX(), FIELD_WIDTH_METERS - state.poseMeters.getY());
+          new Translation2d(FIELD_WIDTH_METERS - state.poseMeters.getX(), state.poseMeters.getY());
       Rotation2d transformedHeading = state.poseMeters.getRotation().plus(Rotation2d.fromRadians(Math.PI);
       Rotation2d transformedHolonomicRotation = state.holonomicRotation.plus(Rotation2d.fromRadians(Math.PI);
 


### PR DESCRIPTION
state.poseMeters.getRotation().times(-1) will return -PI when PI is inputted, but when the robot is on the opposing alliance, the rotation needs to be 0 degrees if 180 is inputted, to preserve the holonomic rotation facing the grid.

The cpp equivalent for this still needs to be made.

Co-authored-by: Alexander Hamilton <a.hamilton72006@gmail.com>