### PR TITLE
Add equality checking for PathPoints

### DIFF
--- a/pathplannerlib/src/main/java/com/pathplanner/lib/PathPoint.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/PathPoint.java
@@ -84,4 +84,21 @@ public class PathPoint {
     return new PathPoint(
         currentPose.getTranslation(), currentPose.getRotation(), currentSpeeds.vxMetersPerSecond);
   }
+
+  /**
+   * Checks equality between this PathPoint and another object.
+   *
+   * @param obj The other object.
+   * @return Whether the two objects are equal or not.
+   */
+  @Override
+  public boolean equals(Object obj) {
+    if (obj instanceof PathPoint) {
+      return ((PathPoint) obj).position.equals(position)
+          && ((PathPoint) obj).heading.equals(heading)
+          && ((PathPoint) obj).holonomicRotation.equals(holonomicRotation);
+    }
+    return false;
+  }
+
 }

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/PathPoint.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/PathPoint.java
@@ -100,5 +100,4 @@ public class PathPoint {
     }
     return false;
   }
-
 }


### PR DESCRIPTION
One great feature of WPILib's `Pose2d` is the ability to [equality-check](https://github.com/wpilibsuite/allwpilib/blob/aa34aacf6eff05477400bbcc46a2e9e4014e0059/wpimath/src/main/java/edu/wpi/first/math/geometry/Pose2d.java#L272-L279
) the objects.

I've ported the logic for PathPoints. 

