### PR TITLE
Create a GitHub Actions workflow to publish generated Javadoc to GitHub Pages

### DIFF
--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Deploy generated Javadoc to GitHub Pages
         uses: s0/git-publish-subdir-action@v2.6.0
         env:
-          REPO: git@github.com:jasonli0616/pathplanner.git #change to git@github.com:mjansen4857/pathplanner.git before merge
+          REPO: git@github.com:mjansen4857/pathplanner.git
           FOLDER: pathplannerlib/build/docs/javadoc
           BRANCH: gh-pages
           TARGET_DIR: docs/java

--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -23,3 +23,4 @@ jobs:
           TARGET_DIR: docs/java
           SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_PRIVATE_KEY }}
           MESSAGE: Publish Java docs from PathPlannerLib
+          SQUASH_HISTORY: true

--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -1,8 +1,7 @@
 name: Publish PathPlannerLib Javadoc
 
 on:
-  release:
-    types: [released]
+  workflow_dispatch
 
 jobs:
   build-and-deploy:

--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -8,6 +8,8 @@ jobs:
   build:
     runs-on: ubuntu-22.04
     steps:
+      - name: Checkout repo
+        uses: actions/checkout@v3
       - name: Build PathPlannerLib
         working-directory: pathplannerlib
         run: |

--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -19,7 +19,8 @@ jobs:
         uses: s0/git-publish-subdir-action@v2.6.0
         env:
           REPO: git@github.com:jasonli0616/pathplanner.git #change to git@github.com:mjansen4857/pathplanner.git before merge
-          BRANCH: gh-pages
           FOLDER: pathplannerlib/build/docs/javadoc
+          BRANCH: gh-pages
+          TARGET_DIR: docs/java
           SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_PRIVATE_KEY }}
           MESSAGE: Publish docs from PathPlannerLib version ${{ github.event.release.tag_name }}

--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -1,0 +1,26 @@
+name: Publish PathPlannerLib Javadoc
+
+on:
+  release:
+    types: [released]
+
+jobs:
+  build:
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Build PathPlannerLib
+        working-directory: pathplannerlib
+        run: |
+            ./gradlew build -PreleaseMode
+            ./gradlew publish -PreleaseMode
+  push-docs:
+    needs: [build]
+    runs-on: ubuntu-22.04
+    steps:
+      - name: Deploy generated Javadoc to GitHub Pages
+        uses: s0/git-publish-subdir-action@v2.6.0
+        env:
+          REPO: git@github.com:jasonli0616/pathplanner.git #change to git@github.com:mjansen4857/pathplanner.git before merge
+          BRANCH: gh-pages
+          FOLDER: pathplannerlib/build/docs/javadoc
+          SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_PRIVATE_KEY }}

--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -5,7 +5,7 @@ on:
     types: [released]
 
 jobs:
-  build:
+  build-and-deploy:
     runs-on: ubuntu-22.04
     steps:
       - name: Checkout repo
@@ -15,10 +15,6 @@ jobs:
         run: |
             ./gradlew build -PreleaseMode
             ./gradlew publish -PreleaseMode
-  push-docs:
-    needs: [build]
-    runs-on: ubuntu-22.04
-    steps:
       - name: Deploy generated Javadoc to GitHub Pages
         uses: s0/git-publish-subdir-action@v2.6.0
         env:

--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -22,3 +22,4 @@ jobs:
           BRANCH: gh-pages
           FOLDER: pathplannerlib/build/docs/javadoc
           SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_PRIVATE_KEY }}
+          MESSAGE: Publish docs from PathPlannerLib version ${{ github.event.release.tag_name }}

--- a/.github/workflows/publish-javadoc.yml
+++ b/.github/workflows/publish-javadoc.yml
@@ -22,4 +22,4 @@ jobs:
           BRANCH: gh-pages
           TARGET_DIR: docs/java
           SSH_PRIVATE_KEY: ${{ secrets.DEPLOY_PRIVATE_KEY }}
-          MESSAGE: Publish docs from PathPlannerLib version ${{ github.event.release.tag_name }}
+          MESSAGE: Publish Java docs from PathPlannerLib


### PR DESCRIPTION
As pitched in https://github.com/mjansen4857/pathplanner/pull/310

# Overview

The GitHub Actions workflow is triggered based on a release (does not include drafts, or pre-release). Once a release is published (either directly, from a draft, or from a pre-release), it will assume that it's the latest version of PathPlannerLib.

It will build PathPlannerLib, and push the Javadoc directory to the `gh-pages` branch. It is not necessary to create a new branch for each version, because GitHub Pages can only host one version, and the generated Javadocs do not have versions built in. It will always be the latest version.

## Working demo

You can see a demo in my fork on the repo, at https://github.com/jasonli0616/pathplanner and https://jasonli0616.github.io/pathplanner/docs/java/

# How to implement

Because the workflow must push to the repo, it requires a bit of configuring on your (repo owner's) end to get it working.

## 1. [Deploy keys](https://docs.github.com/en/authentication/connecting-to-github-with-ssh/managing-deploy-keys#deploy-keys)

The workflow uses the [s0/git-publish-subdir-action](https://github.com/s0/git-publish-subdir-action) dependency to push a directory (in this case, the `pathplannerlib/build/docs/javadoc` directory) to a branch on a repo.

You can follow [their instructions](https://github.com/s0/git-publish-subdir-action#usage-with-deploy-keys) to set up the deploy keys.

In short:

1. Run `ssh-keygen -t ed25519 -C "your_email@example.com"`, substituting your email **(leave passphrase empty, when prompted)**
2. Add a secret in `(repo) > Settings > Secrets and variables > Actions > New repository secret`, name it `DEPLOY_PRIVATE_KEY` and paste in the private key
3. Add a deploy key in `(repo) > Settings > Deploy keys > Add deploy key` and paste in your public key

## 2. Configure GitHub Pages

The GitHub Pages must be configured to be hosted from the `gh-pages` branch, at the `/(root)` directory.

**See image for reference:**

![Screenshot of GitHub Pages configuration](https://github.com/mjansen4857/pathplanner/assets/75756042/75ada2d6-9cea-48a6-822d-803c0c017de5)

# Conclusion

The GitHub Actions workflow should now be set up to automatically build and publish the Javadoc on GitHub Pages when a new stable release is published.

Let me know your thoughts and if there are any tweaks or changes that you would prefer.