### PR TITLE
Link Javadoc to external sources (Java API, WPILib API)

### DIFF
--- a/pathplannerlib/build.gradle
+++ b/pathplannerlib/build.gradle
@@ -150,6 +150,12 @@ spotless {
     }
 }
 
+javadoc {
+    options {
+        links 'https://docs.oracle.com/en/java/javase/11/docs/api/', 'https://github.wpilib.org/allwpilib/docs/release/java/'
+    }
+}
+
 apply from: 'publish.gradle'
 
 wrapper {


### PR DESCRIPTION
A continuation of https://github.com/mjansen4857/pathplanner/pull/313, one last thing:

This should now link the Java docs and WPILib docs in the PathPlanner docs, where it's referenced.