### PR TITLE
Fix Trajectory.State not copying all fields correctly

### DIFF
--- a/pathplannerlib/build.gradle
+++ b/pathplannerlib/build.gradle
@@ -45,6 +45,7 @@ dependencies {
     testImplementation 'org.junit.jupiter:junit-jupiter-api:5.9.0'
     testImplementation 'org.junit.jupiter:junit-jupiter-params:5.9.0'
     testRuntimeOnly 'org.junit.jupiter:junit-jupiter-engine:5.9.0'
+    testRuntimeOnly "us.hebi.quickbuf:quickbuf-runtime:1.3.2"
 }
 
 // Set up exports properly

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/path/PathPlannerTrajectory.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/path/PathPlannerTrajectory.java
@@ -323,6 +323,7 @@ public class PathPlannerTrajectory {
       reversed.velocityMps = -velocityMps;
       reversed.accelerationMpsSq = -accelerationMpsSq;
       reversed.headingAngularVelocityRps = -headingAngularVelocityRps;
+      reversed.positionMeters = positionMeters;
       reversed.heading =
           Rotation2d.fromDegrees(MathUtil.inputModulus(heading.getDegrees() + 180, -180, 180));
       reversed.targetHolonomicRotation = targetHolonomicRotation;

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/path/PathPlannerTrajectory.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/path/PathPlannerTrajectory.h
@@ -107,9 +107,10 @@ public:
 			reversed.velocity = -velocity;
 			reversed.acceleration = -acceleration;
 			reversed.headingAngularVelocity = -headingAngularVelocity;
+			reversed.position = position;
 			reversed.heading = frc::Rotation2d(
-					frc::InputModulus(reversed.heading.Degrees() + 180_deg,
-							-180_deg, 180_deg));
+					frc::InputModulus(heading.Degrees() + 180_deg, -180_deg,
+							180_deg));
 			reversed.targetHolonomicRotation = targetHolonomicRotation;
 			reversed.curvature = -curvature;
 			reversed.deltaPos = deltaPos;

--- a/pathplannerlib/src/test/java/com/pathplanner/lib/path/PathPlannerTrajectoryTest.java
+++ b/pathplannerlib/src/test/java/com/pathplanner/lib/path/PathPlannerTrajectoryTest.java
@@ -1,0 +1,43 @@
+package com.pathplanner.lib.path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import org.junit.jupiter.api.Test;
+
+public class PathPlannerTrajectoryTest {
+  private static final double EPSILON = 1e-6;
+
+  @Test
+  public void testReverse() {
+    PathPlannerTrajectory.State state = new PathPlannerTrajectory.State();
+    state.timeSeconds = 1.91;
+    state.velocityMps = 2.29;
+    state.accelerationMpsSq = 35.04;
+    state.headingAngularVelocityRps = 174;
+    state.positionMeters = new Translation2d(1.1, 2.2);
+    state.heading = Rotation2d.fromDegrees(191);
+    state.targetHolonomicRotation = Rotation2d.fromDegrees(22.9);
+    state.curvatureRadPerMeter = 3.504;
+    state.constraints = new PathConstraints(1, 2, 3, 4);
+
+    // Round-trip reversal should yield the original state
+    state = state.reverse();
+    state = state.reverse();
+
+    assertEquals(1.91, state.timeSeconds, EPSILON);
+    assertEquals(2.29, state.velocityMps, EPSILON);
+    assertEquals(35.04, state.accelerationMpsSq, EPSILON);
+    assertEquals(174, state.headingAngularVelocityRps);
+    assertEquals(1.1, state.positionMeters.getX());
+    assertEquals(2.2, state.positionMeters.getY());
+    assertEquals(191 - 360, state.heading.getDegrees(), EPSILON);
+    assertEquals(22.9, state.targetHolonomicRotation.getDegrees(), EPSILON);
+    assertEquals(3.504, state.curvatureRadPerMeter);
+    assertEquals(1, state.constraints.getMaxVelocityMps());
+    assertEquals(2, state.constraints.getMaxAccelerationMpsSq());
+    assertEquals(3, state.constraints.getMaxAngularVelocityRps());
+    assertEquals(4, state.constraints.getMaxAngularAccelerationRpsSq());
+  }
+}

--- a/pathplannerlib/src/test/native/cpp/pathplanner/lib/path/PathPlannerTrajectoryTest.cpp
+++ b/pathplannerlib/src/test/native/cpp/pathplanner/lib/path/PathPlannerTrajectoryTest.cpp
@@ -1,0 +1,38 @@
+#include <gtest/gtest.h>
+
+#include "pathplanner/lib/path/PathPlannerTrajectory.h"
+
+using namespace pathplanner;
+
+TEST(PathPlannerTrajectoryTest, TestReverse) {
+	PathPlannerTrajectory::State state;
+	state.time = 1.91_s;
+	state.velocity = 2.29_mps;
+	state.acceleration = 35.04_mps_sq;
+	state.headingAngularVelocity = 174_rad_per_s;
+	state.position = frc::Translation2d {1.1_m, 2.2_m};
+	state.heading = frc::Rotation2d {191_deg};
+	state.targetHolonomicRotation = frc::Rotation2d {22.9_deg};
+	state.curvature = units::curvature_t {3.504};
+	state.constraints = PathConstraints {1_mps, 2_mps_sq, 3_rad_per_s, 4_rad_per_s_sq};
+	state.deltaPos = 0.1_m;
+
+	// Round-trip reversal should yield the original state
+	state = state.reverse();
+	state = state.reverse();
+
+	EXPECT_DOUBLE_EQ(1.91, state.time());
+	EXPECT_DOUBLE_EQ(2.29, state.velocity());
+	EXPECT_DOUBLE_EQ(35.04, state.acceleration());
+	EXPECT_DOUBLE_EQ(174, state.headingAngularVelocity());
+	EXPECT_DOUBLE_EQ(1.1, state.position.X()());
+	EXPECT_DOUBLE_EQ(2.2, state.position.Y()());
+	EXPECT_DOUBLE_EQ(191 - 360, state.heading.Degrees()());
+	EXPECT_DOUBLE_EQ(22.9, state.targetHolonomicRotation.Degrees()());
+	EXPECT_DOUBLE_EQ(3.504, state.curvature());
+	EXPECT_DOUBLE_EQ(1.0, state.constraints.getMaxVelocity()());
+	EXPECT_DOUBLE_EQ(2.0, state.constraints.getMaxAcceleration()());
+	EXPECT_DOUBLE_EQ(3.0, state.constraints.getMaxAngularVelocity()());
+	EXPECT_DOUBLE_EQ(4.0, state.constraints.getMaxAngularAcceleration()());
+	EXPECT_DOUBLE_EQ(0.1, state.deltaPos());
+}


### PR DESCRIPTION
The reverse function in PathPlannerTrajectory was not including all of the fields in either language, so if a DiffDrive path was reversed it would always try to drive to (0, 0). This fixes it and adds test coverage.