### PR TITLE
Expose holomonic preview path in PathPlannerPath

### DIFF
--- a/pathplannerlib/src/main/java/com/pathplanner/lib/path/PathPlannerPath.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/path/PathPlannerPath.java
@@ -271,7 +271,7 @@ public class PathPlannerPath {
       JSONObject previewStartingStateJson = (JSONObject) pathJson.get("previewStartingState");
       if (previewStartingStateJson != null) {
         previewStartingRotation =
-            Rotation2d.fromDegrees((Double) previewStartingStateJson.get("rotation"));
+            Rotation2d.fromDegrees(((Number) previewStartingStateJson.get("rotation")).doubleValue());
       }
     }
 

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/path/PathPlannerPath.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/path/PathPlannerPath.java
@@ -64,6 +64,28 @@ public class PathPlannerPath {
   }
 
   /**
+   * Create a new path planner path
+   *
+   * @param bezierPoints List of points representing the cubic Bezier curve of the path
+   * @param holonomicRotations List of rotation targets along the path
+   * @param constraintZones List of constraint zones along the path
+   * @param eventMarkers List of event markers along the path
+   * @param globalConstraints The global constraints of the path
+   * @param goalEndState The goal end state of the path
+   * @param reversed Should the robot follow the path reversed (differential drive only)
+   */
+  public PathPlannerPath(
+          List<Translation2d> bezierPoints,
+          List<RotationTarget> holonomicRotations,
+          List<ConstraintsZone> constraintZones,
+          List<EventMarker> eventMarkers,
+          PathConstraints globalConstraints,
+          GoalEndState goalEndState,
+          boolean reversed) {
+    this(bezierPoints, holonomicRotations, constraintZones, eventMarkers, globalConstraints, goalEndState, reversed, Rotation2d.fromDegrees(0));
+  }
+
+  /**
    * Simplified constructor to create a path with no rotation targets, constraint zones, or event
    * markers.
    *

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/path/PathPlannerPath.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/path/PathPlannerPath.java
@@ -75,14 +75,22 @@ public class PathPlannerPath {
    * @param reversed Should the robot follow the path reversed (differential drive only)
    */
   public PathPlannerPath(
-          List<Translation2d> bezierPoints,
-          List<RotationTarget> holonomicRotations,
-          List<ConstraintsZone> constraintZones,
-          List<EventMarker> eventMarkers,
-          PathConstraints globalConstraints,
-          GoalEndState goalEndState,
-          boolean reversed) {
-    this(bezierPoints, holonomicRotations, constraintZones, eventMarkers, globalConstraints, goalEndState, reversed, Rotation2d.fromDegrees(0));
+      List<Translation2d> bezierPoints,
+      List<RotationTarget> holonomicRotations,
+      List<ConstraintsZone> constraintZones,
+      List<EventMarker> eventMarkers,
+      PathConstraints globalConstraints,
+      GoalEndState goalEndState,
+      boolean reversed) {
+    this(
+        bezierPoints,
+        holonomicRotations,
+        constraintZones,
+        eventMarkers,
+        globalConstraints,
+        goalEndState,
+        reversed,
+        Rotation2d.fromDegrees(0));
   }
 
   /**
@@ -293,7 +301,8 @@ public class PathPlannerPath {
       JSONObject previewStartingStateJson = (JSONObject) pathJson.get("previewStartingState");
       if (previewStartingStateJson != null) {
         previewStartingRotation =
-            Rotation2d.fromDegrees(((Number) previewStartingStateJson.get("rotation")).doubleValue());
+            Rotation2d.fromDegrees(
+                ((Number) previewStartingStateJson.get("rotation")).doubleValue());
       }
     }
 

--- a/pathplannerlib/src/main/native/cpp/pathplanner/lib/path/PathPlannerPath.cpp
+++ b/pathplannerlib/src/main/native/cpp/pathplanner/lib/path/PathPlannerPath.cpp
@@ -130,10 +130,10 @@ PathPlannerPath PathPlannerPath::fromJson(const wpi::json &json) {
 	}
 
 	frc::Rotation2d previewStartingRotation;
-	if (json.contains("previewStartingState")) {
-		auto jsonStartingState = json["previewStartingState"];
+	if (json.contains("previewStartingState") && !json.at("previewStartingState").is_null()) {
+		auto jsonStartingState = json.at("previewStartingState");
 		previewStartingRotation = frc::Rotation2d(
-				units::degree_t(jsonStartingState["rotation"]));
+				units::degree_t(jsonStartingState.at("rotation").get<double>()));
 	}
 
 	return PathPlannerPath(bezierPoints, rotationTargets, constraintZones,

--- a/pathplannerlib/src/main/native/cpp/pathplanner/lib/path/PathPlannerPath.cpp
+++ b/pathplannerlib/src/main/native/cpp/pathplanner/lib/path/PathPlannerPath.cpp
@@ -130,10 +130,12 @@ PathPlannerPath PathPlannerPath::fromJson(const wpi::json &json) {
 	}
 
 	frc::Rotation2d previewStartingRotation;
-	if (json.contains("previewStartingState") && !json.at("previewStartingState").is_null()) {
+	if (json.contains("previewStartingState")
+			&& !json.at("previewStartingState").is_null()) {
 		auto jsonStartingState = json.at("previewStartingState");
 		previewStartingRotation = frc::Rotation2d(
-				units::degree_t(jsonStartingState.at("rotation").get<double>()));
+				units::degree_t(
+						jsonStartingState.at("rotation").get<double>()));
 	}
 
 	return PathPlannerPath(bezierPoints, rotationTargets, constraintZones,

--- a/pathplannerlib/src/main/native/cpp/pathplanner/lib/path/PathPlannerPath.cpp
+++ b/pathplannerlib/src/main/native/cpp/pathplanner/lib/path/PathPlannerPath.cpp
@@ -14,11 +14,11 @@ PathPlannerPath::PathPlannerPath(std::vector<frc::Translation2d> bezierPoints,
 		std::vector<ConstraintsZone> constraintZones,
 		std::vector<EventMarker> eventMarkers,
 		PathConstraints globalConstraints, GoalEndState goalEndState,
-		bool reversed, PreviewStartingState previewStartingState) : m_bezierPoints(
+		bool reversed, frc::Rotation2d previewStartingRotation) : m_bezierPoints(
 		bezierPoints), m_rotationTargets(rotationTargets), m_constraintZones(
 		constraintZones), m_eventMarkers(eventMarkers), m_globalConstraints(
-		globalConstraints), m_goalEndState(goalEndState), m_reversed(reversed), m_previewStartingState(
-		previewStartingState) {
+		globalConstraints), m_goalEndState(goalEndState), m_reversed(reversed), m_previewStartingRotation(
+		previewStartingRotation) {
 	m_allPoints = PathPlannerPath::createPath(m_bezierPoints, m_rotationTargets,
 			m_constraintZones);
 
@@ -42,6 +42,7 @@ void PathPlannerPath::hotReload(const wpi::json &json) {
 	m_goalEndState = updatedPath.m_goalEndState;
 	m_reversed = updatedPath.m_reversed;
 	m_allPoints = updatedPath.m_allPoints;
+	m_previewStartingRotation = updatedPath.m_previewStartingRotation;
 }
 
 std::vector<frc::Translation2d> PathPlannerPath::bezierFromPoses(
@@ -128,16 +129,16 @@ PathPlannerPath PathPlannerPath::fromJson(const wpi::json &json) {
 		eventMarkers.push_back(EventMarker::fromJson(markerJson));
 	}
 
-	PreviewStartingState previewStartingState;
+	frc::Rotation2d previewStartingRotation;
 	if (json.contains("previewStartingState")) {
 		auto jsonStartingState = json["previewStartingState"];
-		previewStartingState = { units::degree_t(jsonStartingState["rotation"]),
-				units::meters_per_second_t(jsonStartingState["velocity"]) };
+		previewStartingRotation = frc::Rotation2d(
+				units::degree_t(jsonStartingState["rotation"]));
 	}
 
 	return PathPlannerPath(bezierPoints, rotationTargets, constraintZones,
 			eventMarkers, globalConstraints, goalEndState, reversed,
-			previewStartingState);
+			previewStartingRotation);
 }
 
 std::vector<frc::Translation2d> PathPlannerPath::bezierPointsFromWaypointsJson(
@@ -247,8 +248,8 @@ frc::Pose2d PathPlannerPath::getStartingDifferentialPose() {
 	return frc::Pose2d(startPos, heading);
 }
 
-frc::Pose2d PathPlannerPath::getStartingHolomonicPreviewPose() {
-	return frc::Pose2d(getPoint(0).position, m_previewStartingState.m_rotation);
+frc::Pose2d PathPlannerPath::getPreviewStartingHolonomicPose() {
+	return frc::Pose2d(getPoint(0).position, m_previewStartingRotation);
 }
 
 void PathPlannerPath::precalcValues() {

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/path/PathPlannerPath.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/path/PathPlannerPath.h
@@ -19,6 +19,16 @@
 namespace pathplanner {
 class PathPlannerPath {
 public:
+
+	/**
+	 * Container for the preview starting state
+	 */
+	class PreviewStartingState {
+	public:
+		frc::Rotation2d m_rotation;
+		units::meters_per_second_t m_velocity;
+	};
+
 	/**
 	 * Create a new path planner path
 	 *
@@ -35,7 +45,8 @@ public:
 			std::vector<ConstraintsZone> constraintZones,
 			std::vector<EventMarker> eventMarkers,
 			PathConstraints globalConstraints, GoalEndState goalEndState,
-			bool reversed);
+			bool reversed, PreviewStartingState previewStartingState =
+					PreviewStartingState());
 
 	/**
 	 * Simplified constructor to create a path with no rotation targets, constraint zones, or event
@@ -80,6 +91,13 @@ public:
 	 * @return Pose at the path's starting point
 	 */
 	frc::Pose2d getStartingDifferentialPose();
+
+	/**
+	 * Get the starting pose for the holomonic path based on the preview settings
+	 *
+	 * @return Pose at the path's starting point
+	 */
+	frc::Pose2d getStartingHolomonicPreviewPose();
 
 	/**
 	 * Get the constraints for a point along the path
@@ -234,5 +252,6 @@ private:
 	GoalEndState m_goalEndState;
 	std::vector<PathPoint> m_allPoints;
 	bool m_reversed;
+	PreviewStartingState m_previewStartingState;
 };
 }

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/path/PathPlannerPath.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/path/PathPlannerPath.h
@@ -19,16 +19,6 @@
 namespace pathplanner {
 class PathPlannerPath {
 public:
-
-	/**
-	 * Container for the preview starting state
-	 */
-	class PreviewStartingState {
-	public:
-		frc::Rotation2d m_rotation;
-		units::meters_per_second_t m_velocity;
-	};
-
 	/**
 	 * Create a new path planner path
 	 *
@@ -45,8 +35,8 @@ public:
 			std::vector<ConstraintsZone> constraintZones,
 			std::vector<EventMarker> eventMarkers,
 			PathConstraints globalConstraints, GoalEndState goalEndState,
-			bool reversed, PreviewStartingState previewStartingState =
-					PreviewStartingState());
+			bool reversed, frc::Rotation2d previewStartingRotation =
+					frc::Rotation2d());
 
 	/**
 	 * Simplified constructor to create a path with no rotation targets, constraint zones, or event
@@ -93,11 +83,13 @@ public:
 	frc::Pose2d getStartingDifferentialPose();
 
 	/**
-	 * Get the starting pose for the holomonic path based on the preview settings
+	 * Get the starting pose for the holomonic path based on the preview settings.
+	 *
+	 * NOTE: This should only be used for the first path you are running, and only if you are not using an auto mode file. Using this pose to reset the robots pose between sequential paths will cause a loss of accuracy.
 	 *
 	 * @return Pose at the path's starting point
 	 */
-	frc::Pose2d getStartingHolomonicPreviewPose();
+	frc::Pose2d getPreviewStartingHolonomicPose();
 
 	/**
 	 * Get the constraints for a point along the path
@@ -252,6 +244,6 @@ private:
 	GoalEndState m_goalEndState;
 	std::vector<PathPoint> m_allPoints;
 	bool m_reversed;
-	PreviewStartingState m_previewStartingState;
+	frc::Rotation2d m_previewStartingRotation;
 };
 }

--- a/pathplannerlib/src/test/java/com/pathplanner/lib/path/PathPlannerPathTest.java
+++ b/pathplannerlib/src/test/java/com/pathplanner/lib/path/PathPlannerPathTest.java
@@ -52,8 +52,8 @@ public class PathPlannerPathTest {
             new PathConstraints(1, 2, 3, 4),
             new GoalEndState(0, Rotation2d.fromDegrees(0)),
             true,
-            new PathPlannerPath.PreviewStartingState(Rotation2d.fromDegrees(90), 0));
-    Pose2d initialPose = path.getStartingHolomonicPreviewPose();
+            Rotation2d.fromDegrees(90));
+    Pose2d initialPose = path.getPreviewStartingHolonomicPose();
     assertNotNull(initialPose);
     assertEquals(2, initialPose.getX(), EPSILON);
     assertEquals(1, initialPose.getY(), EPSILON);
@@ -76,7 +76,7 @@ public class PathPlannerPathTest {
             new GoalEndState(0, Rotation2d.fromDegrees(0)),
             true,
             null);
-    Pose2d initialPose = path.getStartingHolomonicPreviewPose();
+    Pose2d initialPose = path.getPreviewStartingHolonomicPose();
     assertNotNull(initialPose);
     assertEquals(2, initialPose.getX(), EPSILON);
     assertEquals(1, initialPose.getY(), EPSILON);

--- a/pathplannerlib/src/test/java/com/pathplanner/lib/path/PathPlannerPathTest.java
+++ b/pathplannerlib/src/test/java/com/pathplanner/lib/path/PathPlannerPathTest.java
@@ -1,0 +1,85 @@
+package com.pathplanner.lib.path;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class PathPlannerPathTest {
+  private static final double EPSILON = 1e-6;
+
+  @Test
+  public void testDifferentialStartingPose() {
+    PathPlannerPath path =
+        new PathPlannerPath(
+            List.of(
+                new Translation2d(2, 1),
+                new Translation2d(3.12, 1),
+                new Translation2d(3.67, 1.00),
+                new Translation2d(5.19, 1.00)),
+            new ArrayList<>(),
+            new ArrayList<>(),
+            new ArrayList<>(),
+            new PathConstraints(1, 2, 3, 4),
+            new GoalEndState(0, Rotation2d.fromDegrees(0)),
+            true,
+            null);
+
+    Pose2d initialPose = path.getStartingDifferentialPose();
+    assertNotNull(initialPose);
+    assertEquals(2, initialPose.getX(), EPSILON);
+    assertEquals(1, initialPose.getY(), EPSILON);
+    assertEquals(180, initialPose.getRotation().getDegrees(), EPSILON);
+  }
+
+  @Test
+  public void testHolomonicStartingPoseSet() {
+    PathPlannerPath path =
+        new PathPlannerPath(
+            List.of(
+                new Translation2d(2, 1),
+                new Translation2d(3.12, 1),
+                new Translation2d(3.67, 1.00),
+                new Translation2d(5.19, 1.00)),
+            new ArrayList<>(),
+            new ArrayList<>(),
+            new ArrayList<>(),
+            new PathConstraints(1, 2, 3, 4),
+            new GoalEndState(0, Rotation2d.fromDegrees(0)),
+            true,
+            new PathPlannerPath.PreviewStartingState(Rotation2d.fromDegrees(90), 0));
+    Pose2d initialPose = path.getStartingHolomonicPreviewPose();
+    assertNotNull(initialPose);
+    assertEquals(2, initialPose.getX(), EPSILON);
+    assertEquals(1, initialPose.getY(), EPSILON);
+    assertEquals(90, initialPose.getRotation().getDegrees(), EPSILON);
+  }
+
+  @Test
+  public void testHolomonicStartingPoseNotSet() {
+    PathPlannerPath path =
+        new PathPlannerPath(
+            List.of(
+                new Translation2d(2, 1),
+                new Translation2d(3.12, 1),
+                new Translation2d(3.67, 1.00),
+                new Translation2d(5.19, 1.00)),
+            new ArrayList<>(),
+            new ArrayList<>(),
+            new ArrayList<>(),
+            new PathConstraints(1, 2, 3, 4),
+            new GoalEndState(0, Rotation2d.fromDegrees(0)),
+            true,
+            null);
+    Pose2d initialPose = path.getStartingHolomonicPreviewPose();
+    assertNotNull(initialPose);
+    assertEquals(2, initialPose.getX(), EPSILON);
+    assertEquals(1, initialPose.getY(), EPSILON);
+    assertEquals(0, initialPose.getRotation().getDegrees(), EPSILON);
+  }
+}

--- a/pathplannerlib/src/test/native/cpp/pathplanner/lib/path/PathPlannerPathTest.cpp
+++ b/pathplannerlib/src/test/native/cpp/pathplanner/lib/path/PathPlannerPathTest.cpp
@@ -1,0 +1,55 @@
+#include <gtest/gtest.h>
+#include "pathplanner/lib/path/PathPlannerPath.h"
+
+using namespace pathplanner;
+
+TEST(PathPlannerPathTest, DifferentialStartingPose) {
+	PathPlannerPath path(
+			std::vector<frc::Translation2d> {frc::Translation2d(2_m, 1_m), frc::Translation2d(3.12_m, 1_m), frc::Translation2d(3.67_m, 1.00_m), frc::Translation2d(5.19_m, 1.00_m)},
+			std::vector<RotationTarget>(),
+			std::vector<ConstraintsZone>(),
+			std::vector<EventMarker>(),
+			PathConstraints {1_mps, 2_mps_sq, 3_rad_per_s, 4_rad_per_s_sq},
+			GoalEndState(0_mps, 0_deg),
+			true);
+
+	frc::Pose2d initialPose = path.getStartingDifferentialPose();
+	EXPECT_EQ(2, initialPose.X()());
+	EXPECT_EQ(1, initialPose.Y()());
+	EXPECT_EQ(180, initialPose.Rotation().Degrees()());
+}
+
+TEST(PathPlannerPathTest, HolomonicStartingPoseSet)
+{
+	PathPlannerPath path(
+			std::vector<frc::Translation2d> {frc::Translation2d(2_m, 1_m), frc::Translation2d(3.12_m, 1_m), frc::Translation2d(3.67_m, 1.00_m), frc::Translation2d(5.19_m, 1.00_m)},
+			std::vector<RotationTarget>(),
+			std::vector<ConstraintsZone>(),
+			std::vector<EventMarker>(),
+			PathConstraints {1_mps, 2_mps_sq, 3_rad_per_s, 4_rad_per_s_sq},
+			GoalEndState(0_mps, 0_deg),
+			true,
+			PathPlannerPath::PreviewStartingState {90_deg, 0_mps});
+
+	frc::Pose2d initialPose = path.getStartingHolomonicPreviewPose();
+	EXPECT_EQ(2, initialPose.X()());
+	EXPECT_EQ(1, initialPose.Y()());
+	EXPECT_EQ(90, initialPose.Rotation().Degrees()());
+}
+
+TEST(PathPlannerPathTest, HolomonicStartingPoseNotSet)
+{
+	PathPlannerPath path(
+			std::vector<frc::Translation2d> {frc::Translation2d(2_m, 1_m), frc::Translation2d(3.12_m, 1_m), frc::Translation2d(3.67_m, 1.00_m), frc::Translation2d(5.19_m, 1.00_m)},
+			std::vector<RotationTarget>(),
+			std::vector<ConstraintsZone>(),
+			std::vector<EventMarker>(),
+			PathConstraints {1_mps, 2_mps_sq, 3_rad_per_s, 4_rad_per_s_sq},
+			GoalEndState(0_mps, 0_deg),
+			true);
+
+	frc::Pose2d initialPose = path.getStartingHolomonicPreviewPose();
+	EXPECT_EQ(2, initialPose.X()());
+	EXPECT_EQ(1, initialPose.Y()());
+	EXPECT_EQ(0, initialPose.Rotation().Degrees()());
+}

--- a/pathplannerlib/src/test/native/cpp/pathplanner/lib/path/PathPlannerPathTest.cpp
+++ b/pathplannerlib/src/test/native/cpp/pathplanner/lib/path/PathPlannerPathTest.cpp
@@ -29,9 +29,9 @@ TEST(PathPlannerPathTest, HolomonicStartingPoseSet)
 			PathConstraints {1_mps, 2_mps_sq, 3_rad_per_s, 4_rad_per_s_sq},
 			GoalEndState(0_mps, 0_deg),
 			true,
-			PathPlannerPath::PreviewStartingState {90_deg, 0_mps});
+			frc::Rotation2d {90_deg});
 
-	frc::Pose2d initialPose = path.getStartingHolomonicPreviewPose();
+	frc::Pose2d initialPose = path.getPreviewStartingHolonomicPose();
 	EXPECT_EQ(2, initialPose.X()());
 	EXPECT_EQ(1, initialPose.Y()());
 	EXPECT_EQ(90, initialPose.Rotation().Degrees()());
@@ -48,7 +48,7 @@ TEST(PathPlannerPathTest, HolomonicStartingPoseNotSet)
 			GoalEndState(0_mps, 0_deg),
 			true);
 
-	frc::Pose2d initialPose = path.getStartingHolomonicPreviewPose();
+	frc::Pose2d initialPose = path.getPreviewStartingHolonomicPose();
 	EXPECT_EQ(2, initialPose.X()());
 	EXPECT_EQ(1, initialPose.Y()());
 	EXPECT_EQ(0, initialPose.Rotation().Degrees()());


### PR DESCRIPTION
Similar to #423 . In a localization-less environment it is handy to know the starting pose for swerve paths. This uses the preview state heading, if it is set so you can reset your pose and drive exactly what you see in the gui.