### PR TITLE
Significantly improve pathfinding performance on RIO

### DIFF
--- a/pathplannerlib/src/main/java/com/pathplanner/lib/pathfinding/LocalADStar.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/pathfinding/LocalADStar.java
@@ -259,6 +259,17 @@ public class LocalADStar implements Pathfinder {
         GridPosition goal = requestGoal;
         Translation2d realGoal = requestRealGoalPos;
         Set<GridPosition> obstacles = new HashSet<>(requestObstacles);
+
+        // Change the request booleans based on what will be done this loop
+        if (reset) {
+          requestReset = false;
+        }
+
+        if (minor) {
+          requestMinor = false;
+        } else if (major && (eps - 0.5) <= 1.0) {
+          requestMajor = false;
+        }
         requestLock.readLock().unlock();
 
         if (reset || minor || major) {
@@ -290,7 +301,6 @@ public class LocalADStar implements Pathfinder {
       Set<GridPosition> obstacles) {
     if (needsReset) {
       reset(sStart, sGoal);
-      requestReset = false;
     }
 
     if (doMinor) {
@@ -302,8 +312,6 @@ public class LocalADStar implements Pathfinder {
       pathLock.writeLock().unlock();
 
       newPathAvailable = true;
-
-      requestMinor = false;
     } else if (doMajor) {
       if (eps > 1.0) {
         eps -= 0.5;
@@ -319,10 +327,6 @@ public class LocalADStar implements Pathfinder {
         pathLock.writeLock().unlock();
 
         newPathAvailable = true;
-      }
-
-      if (eps <= 1.0) {
-        requestMajor = false;
       }
     }
   }

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/pathfinding/LocalADStar.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/pathfinding/LocalADStar.java
@@ -463,7 +463,7 @@ public class LocalADStar implements Pathfinder {
       visited.add(check);
 
       for (GridPosition neighbor : getAllNeighbors(check)) {
-        if (!visited.contains(neighbor)) {
+        if (!visited.contains(neighbor) && !queue.contains(neighbor)) {
           queue.add(neighbor);
         }
       }

--- a/pathplannerlib/src/main/native/cpp/pathplanner/lib/pathfinding/LocalADStar.cpp
+++ b/pathplannerlib/src/main/native/cpp/pathplanner/lib/pathfinding/LocalADStar.cpp
@@ -89,7 +89,7 @@ void LocalADStar::runThread() {
 			std::unordered_set < GridPosition > obstacles;
 
 			{
-				std::lock_guard < std::mutex > lock(requestMutex);
+				std::scoped_lock lock { requestMutex };
 				reset = requestReset;
 				minor = requestMinor;
 				major = requestMajor;
@@ -120,7 +120,7 @@ void LocalADStar::runThread() {
 			}
 		} catch (...) {
 			// Something messed up. Reset and hope for the best
-			std::lock_guard < std::mutex > lock(requestMutex);
+			std::scoped_lock lock { requestMutex };
 			requestReset = true;
 		}
 	}
@@ -141,7 +141,7 @@ void LocalADStar::doWork(const bool needsReset, const bool doMinor,
 				realStartPos, realGoalPos, obstacles);
 
 		{
-			std::lock_guard < std::mutex > lock(pathMutex);
+			std::scoped_lock lock { pathMutex };
 			currentPathPoints = path;
 		}
 
@@ -160,7 +160,7 @@ void LocalADStar::doWork(const bool needsReset, const bool doMinor,
 					realStartPos, realGoalPos, obstacles);
 
 			{
-				std::lock_guard < std::mutex > lock(pathMutex);
+				std::scoped_lock lock { pathMutex };
 				currentPathPoints = path;
 			}
 
@@ -174,7 +174,7 @@ std::shared_ptr<PathPlannerPath> LocalADStar::getCurrentPath(
 	std::vector < PathPoint > pathPoints;
 
 	{
-		std::lock_guard < std::mutex > lock(pathMutex);
+		std::scoped_lock lock { pathMutex };
 		pathPoints = currentPathPoints;
 	}
 
@@ -194,7 +194,7 @@ void LocalADStar::setStartPosition(const frc::Translation2d &start) {
 			requestObstacles);
 
 	if (startPos != requestStart) {
-		std::lock_guard < std::mutex > lock(requestMutex);
+		std::scoped_lock lock { requestMutex };
 		requestStart = startPos;
 		requestRealStartPos = start;
 
@@ -207,7 +207,7 @@ void LocalADStar::setGoalPosition(const frc::Translation2d &goal) {
 			requestObstacles);
 
 	if (gridPos != requestGoal) {
-		std::lock_guard < std::mutex > lock(requestMutex);
+		std::scoped_lock lock { requestMutex };
 		requestGoal = gridPos;
 		requestRealGoalPos = goal;
 
@@ -279,7 +279,7 @@ void LocalADStar::setDynamicObstacles(
 	dynamicObstacles.insert(newObs.begin(), newObs.end());
 
 	{
-		std::lock_guard < std::mutex > lock(requestMutex);
+		std::scoped_lock lock { requestMutex };
 		requestObstacles.clear();
 		requestObstacles.insert(staticObstacles.begin(), staticObstacles.end());
 		requestObstacles.insert(dynamicObstacles.begin(),

--- a/pathplannerlib/src/main/native/cpp/pathplanner/lib/pathfinding/LocalADStar.cpp
+++ b/pathplannerlib/src/main/native/cpp/pathplanner/lib/pathfinding/LocalADStar.cpp
@@ -181,6 +181,8 @@ GridPosition LocalADStar::findClosestNonObstacle(const GridPosition &pos) {
 	}
 
 	std::unordered_set < GridPosition > visited;
+	// Workaround to be able to see which what nodes are in the queue while maintaining the ordering of the queue
+	std::unordered_set < GridPosition > workaround;
 	std::queue < GridPosition > queue;
 	for (const GridPosition &gp : getAllNeighbors(pos)) {
 		queue.push(gp);
@@ -188,14 +190,16 @@ GridPosition LocalADStar::findClosestNonObstacle(const GridPosition &pos) {
 
 	while (!queue.empty()) {
 		GridPosition check = queue.front();
+		workaround.erase(check);
 		if (!obstacles.contains(check)) {
 			return check;
 		}
 		visited.emplace(check);
 
 		for (const GridPosition &neighbor : getAllNeighbors(check)) {
-			if (!visited.contains(neighbor)) {
+			if (!visited.contains(neighbor) && !workaround.contains(check)) {
 				queue.push(neighbor);
+				workaround.emplace(neighbor);
 			}
 		}
 

--- a/pathplannerlib/src/main/native/cpp/pathplanner/lib/pathfinding/LocalADStar.cpp
+++ b/pathplannerlib/src/main/native/cpp/pathplanner/lib/pathfinding/LocalADStar.cpp
@@ -99,6 +99,17 @@ void LocalADStar::runThread() {
 				realGoal = requestRealGoalPos;
 				obstacles.insert(requestObstacles.begin(),
 						requestObstacles.end());
+
+				// Change the request booleans based on what will be done this loop
+				if (reset) {
+					requestReset = false;
+				}
+
+				if (minor) {
+					requestMinor = false;
+				} else if (major && (eps - 0.5) <= 1.0) {
+					requestMajor = false;
+				}
 			}
 
 			if (reset || minor || major) {
@@ -122,7 +133,6 @@ void LocalADStar::doWork(const bool needsReset, const bool doMinor,
 		const std::unordered_set<GridPosition> &obstacles) {
 	if (needsReset) {
 		reset(sStart, sGoal);
-		requestReset = false;
 	}
 
 	if (doMinor) {
@@ -136,7 +146,6 @@ void LocalADStar::doWork(const bool needsReset, const bool doMinor,
 		}
 
 		newPathAvailable = true;
-		requestMinor = false;
 	} else if (doMajor) {
 		if (eps > 1.0) {
 			eps -= 0.5;
@@ -156,10 +165,6 @@ void LocalADStar::doWork(const bool needsReset, const bool doMinor,
 			}
 
 			newPathAvailable = true;
-		}
-
-		if (eps <= 1.0) {
-			requestMajor = false;
 		}
 	}
 }

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/pathfinding/LocalADStar.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/pathfinding/LocalADStar.h
@@ -1,6 +1,7 @@
 #pragma once
 
 #include "pathplanner/lib/pathfinding/Pathfinder.h"
+#include "pathplanner/lib/path/PathPoint.h"
 #include <unordered_map>
 #include <unordered_set>
 #include <vector>
@@ -87,39 +88,46 @@ private:
 	std::unordered_set<GridPosition> dynamicObstacles;
 	std::unordered_set<GridPosition> obstacles;
 
-	GridPosition sStart;
-	frc::Translation2d realStartPos;
-	GridPosition sGoal;
-	frc::Translation2d realGoalPos;
+	GridPosition requestStart;
+	frc::Translation2d requestRealStartPos;
+	GridPosition requestGoal;
+	frc::Translation2d requestRealGoalPos;
 
 	double eps;
 
 	std::thread planningThread;
-	std::mutex mutex;
+	std::mutex pathMutex;
+	std::mutex requestMutex;
 
-	bool doMinor;
-	bool doMajor;
-	bool needsReset;
-	bool needsExtract;
+	bool requestMinor;
+	bool requestMajor;
+	bool requestReset;
 	bool newPathAvailable;
 
-	std::vector<frc::Translation2d> currentPath;
+	std::vector<PathPoint> currentPathPoints;
 
 	void runThread();
 
-	void doWork();
+	void doWork(const bool needsReset, const bool doMinor, const bool doMajor,
+			const GridPosition &sStart, const GridPosition &sGoal,
+			const frc::Translation2d &realStartPos,
+			const frc::Translation2d &realGoalPos);
 
 	GridPosition findClosestNonObstacle(const GridPosition &pos);
 
-	std::vector<frc::Translation2d> extractPath();
+	std::vector<PathPoint> extractPath(const GridPosition &sStart,
+			const GridPosition &sGoal, const frc::Translation2d &realStartPos,
+			const frc::Translation2d &realGoalPos);
 
 	bool walkable(const GridPosition &s1, const GridPosition &s2);
 
-	void reset();
+	void reset(const GridPosition &sStart, const GridPosition &sGoal);
 
-	void computeOrImprovePath();
+	void computeOrImprovePath(const GridPosition &sStart,
+			const GridPosition &sGoal);
 
-	void updateState(const GridPosition &s);
+	void updateState(const GridPosition &s, const GridPosition &sStart,
+			const GridPosition &sGoal);
 
 	inline double cost(const GridPosition &sStart, const GridPosition &sGoal) {
 		if (isCollision(sStart, sGoal)) {
@@ -134,7 +142,8 @@ private:
 
 	std::unordered_set<GridPosition> getAllNeighbors(const GridPosition &s);
 
-	std::pair<double, double> key(const GridPosition &s);
+	std::pair<double, double> key(const GridPosition &s,
+			const GridPosition &sStart);
 
 	std::optional<std::pair<GridPosition, std::pair<double, double>>> topKey();
 

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/pathfinding/LocalADStar.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/pathfinding/LocalADStar.h
@@ -86,7 +86,7 @@ private:
 	std::unordered_set<GridPosition> closed;
 	std::unordered_set<GridPosition> staticObstacles;
 	std::unordered_set<GridPosition> dynamicObstacles;
-	std::unordered_set<GridPosition> obstacles;
+	std::unordered_set<GridPosition> requestObstacles;
 
 	GridPosition requestStart;
 	frc::Translation2d requestRealStartPos;
@@ -111,34 +111,43 @@ private:
 	void doWork(const bool needsReset, const bool doMinor, const bool doMajor,
 			const GridPosition &sStart, const GridPosition &sGoal,
 			const frc::Translation2d &realStartPos,
-			const frc::Translation2d &realGoalPos);
+			const frc::Translation2d &realGoalPos,
+			const std::unordered_set<GridPosition> &obstacles);
 
-	GridPosition findClosestNonObstacle(const GridPosition &pos);
+	GridPosition findClosestNonObstacle(const GridPosition &pos,
+			const std::unordered_set<GridPosition> &obstacles);
 
 	std::vector<PathPoint> extractPath(const GridPosition &sStart,
 			const GridPosition &sGoal, const frc::Translation2d &realStartPos,
-			const frc::Translation2d &realGoalPos);
+			const frc::Translation2d &realGoalPos,
+			const std::unordered_set<GridPosition> &obstacles);
 
-	bool walkable(const GridPosition &s1, const GridPosition &s2);
+	bool walkable(const GridPosition &s1, const GridPosition &s2,
+			const std::unordered_set<GridPosition> &obstacles);
 
 	void reset(const GridPosition &sStart, const GridPosition &sGoal);
 
 	void computeOrImprovePath(const GridPosition &sStart,
-			const GridPosition &sGoal);
+			const GridPosition &sGoal,
+			const std::unordered_set<GridPosition> &obstacles);
 
 	void updateState(const GridPosition &s, const GridPosition &sStart,
-			const GridPosition &sGoal);
+			const GridPosition &sGoal,
+			const std::unordered_set<GridPosition> &obstacles);
 
-	inline double cost(const GridPosition &sStart, const GridPosition &sGoal) {
-		if (isCollision(sStart, sGoal)) {
+	inline double cost(const GridPosition &sStart, const GridPosition &sGoal,
+			const std::unordered_set<GridPosition> &obstacles) {
+		if (isCollision(sStart, sGoal, obstacles)) {
 			return std::numeric_limits<double>::infinity();
 		}
 		return heuristic(sStart, sGoal);
 	}
 
-	bool isCollision(const GridPosition &sStart, const GridPosition &sEnd);
+	bool isCollision(const GridPosition &sStart, const GridPosition &sEnd,
+			const std::unordered_set<GridPosition> &obstacles);
 
-	std::unordered_set<GridPosition> getOpenNeighbors(const GridPosition &s);
+	std::unordered_set<GridPosition> getOpenNeighbors(const GridPosition &s,
+			const std::unordered_set<GridPosition> &obstacles);
 
 	std::unordered_set<GridPosition> getAllNeighbors(const GridPosition &s);
 

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/pathfinding/LocalADStar.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/pathfinding/LocalADStar.h
@@ -7,7 +7,7 @@
 #include <vector>
 #include <atomic>
 #include <thread>
-#include <mutex>
+#include <wpi/mutex.h>
 #include <frc/geometry/Translation2d.h>
 #include <optional>
 
@@ -96,8 +96,8 @@ private:
 	double eps;
 
 	std::thread planningThread;
-	std::mutex pathMutex;
-	std::mutex requestMutex;
+	wpi::mutex pathMutex;
+	wpi::mutex requestMutex;
 
 	bool requestMinor;
 	bool requestMajor;


### PR DESCRIPTION
Now typically runs ~50ms for the first path iteration on a RIO 1. The first run will still take up to 500ms in Java if it is the first piece of PathPlannerLib run since it needs to warm up. But, who does that anyways?