### PR TITLE
Initialize m_enabled to true in PPHolonomicDriveController

### DIFF
--- a/pathplannerlib/src/main/native/include/pathplanner/lib/controllers/PPHolonomicDriveController.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/controllers/PPHolonomicDriveController.h
@@ -105,7 +105,7 @@ private:
 	rpsPerMps_t m_mpsToRps;
 
 	frc::Translation2d m_translationError;
-	bool m_enabled;
+	bool m_enabled = true;
 
 	static std::function<std::optional<frc::Rotation2d>()> rotationTargetOverride;
 };


### PR DESCRIPTION
We are currently using PathPlanner for our robot, we are testing the code using a Gazebo simulation. The simulated robot didn't seem to turn at all, while the real robot did it without issue. We looked into it and found that the m_enabled check in PPHolonomicDriveController was failing, we believe it is because the variable is not assigned anything, leaving the compiler to decide its value. On Java the variable is set to true when its declared.