### PR TITLE
Fix idempotency and flipping issue with PathfindingCommand

### DIFF
--- a/pathplannerlib-python/pathplannerlib/commands.py
+++ b/pathplannerlib-python/pathplannerlib/commands.py
@@ -275,6 +275,7 @@ class PathfindingCommand(Command):
     _timer: Timer = Timer()
     _targetPath: Union[PathPlannerPath, None]
     _targetPose: Pose2d
+    _originalTargetPose: Pose2d
     _goalEndState: GoalEndState
     _constraints: PathConstraints
     _poseSupplier: Callable[[], Pose2d]
@@ -332,10 +333,12 @@ class PathfindingCommand(Command):
                         break
             self._targetPath = target_path
             self._targetPose = Pose2d(target_path.getPoint(0).position, targetRotation)
+            self._originalTargetPose = Pose2d(target_path.getPoint(0).position, targetRotation)
             self._goalEndState = GoalEndState(goalEndVel, targetRotation, True)
         else:
             self._targetPath = None
             self._targetPose = target_pose
+            self._originalTargetPose = target_pose
             self._goalEndState = GoalEndState(goal_end_vel, target_pose.rotation(), True)
 
         PathfindingCommand._instances += 1
@@ -352,7 +355,8 @@ class PathfindingCommand(Command):
         if self._targetPath is not None:
             self._targetPose = Pose2d(self._targetPath.getPoint(0).position, self._goalEndState.rotation)
             if self._shouldFlipPath():
-                self._targetPose = flipFieldPose(self._targetPose)
+                self._targetPose = flipFieldPose(self._originalTargetPose)
+                self._goalEndState = GoalEndState(self._goalEndState.velocity, self._targetPose.rotation(), True)
 
         if currentPose.translation().distance(self._targetPose.translation()) < 0.5:
             self._output(ChassisSpeeds())

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/commands/PathfindingCommand.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/commands/PathfindingCommand.java
@@ -27,7 +27,8 @@ public class PathfindingCommand extends Command {
   private final Timer timer = new Timer();
   private final PathPlannerPath targetPath;
   private Pose2d targetPose;
-  private final GoalEndState goalEndState;
+  private Pose2d originalTargetPose;
+  private GoalEndState goalEndState;
   private final PathConstraints constraints;
   private final Supplier<Pose2d> poseSupplier;
   private final Supplier<ChassisSpeeds> speedsSupplier;
@@ -94,6 +95,8 @@ public class PathfindingCommand extends Command {
 
     this.targetPath = targetPath;
     this.targetPose = new Pose2d(this.targetPath.getPoint(0).position, targetRotation);
+    this.originalTargetPose =
+        new Pose2d(this.targetPose.getTranslation(), this.targetPose.getRotation());
     this.goalEndState = new GoalEndState(goalEndVel, targetRotation, true);
     this.constraints = constraints;
     this.controller = controller;
@@ -141,6 +144,8 @@ public class PathfindingCommand extends Command {
 
     this.targetPath = null;
     this.targetPose = targetPose;
+    this.originalTargetPose =
+        new Pose2d(this.targetPose.getTranslation(), this.targetPose.getRotation());
     this.goalEndState = new GoalEndState(goalEndVel, targetPose.getRotation(), true);
     this.constraints = constraints;
     this.controller = controller;
@@ -167,7 +172,8 @@ public class PathfindingCommand extends Command {
     if (targetPath != null) {
       targetPose = new Pose2d(this.targetPath.getPoint(0).position, goalEndState.getRotation());
       if (shouldFlipPath.getAsBoolean()) {
-        targetPose = GeometryUtil.flipFieldPose(targetPose);
+        targetPose = GeometryUtil.flipFieldPose(this.originalTargetPose);
+        goalEndState = new GoalEndState(goalEndState.getVelocity(), targetPose.getRotation());
       }
     }
 

--- a/pathplannerlib/src/main/native/cpp/pathplanner/lib/commands/PathfindingCommand.cpp
+++ b/pathplannerlib/src/main/native/cpp/pathplanner/lib/commands/PathfindingCommand.cpp
@@ -46,6 +46,7 @@ PathfindingCommand::PathfindingCommand(
 
 	m_targetPose = frc::Pose2d(m_targetPath->getPoint(0).position,
 			targetRotation);
+	m_originalTargetPose = m_targetPose;
 	m_goalEndState = GoalEndState(goalEndVel, targetRotation, true);
 
 	m_instances++;
@@ -61,13 +62,13 @@ PathfindingCommand::PathfindingCommand(frc::Pose2d targetPose,
 		std::unique_ptr<PathFollowingController> controller,
 		units::meter_t rotationDelayDistance, ReplanningConfig replanningConfig,
 		frc2::Requirements requirements) : m_targetPath(), m_targetPose(
-		targetPose), m_goalEndState(goalEndVel, targetPose.Rotation(), true), m_constraints(
-		constraints), m_poseSupplier(poseSupplier), m_speedsSupplier(
-		speedsSupplier), m_output(output), m_controller(std::move(controller)), m_rotationDelayDistance(
-		rotationDelayDistance), m_replanningConfig(replanningConfig), m_shouldFlipPath(
-		[]() {
-			return false;
-		}) {
+		targetPose), m_originalTargetPose(targetPose), m_goalEndState(
+		goalEndVel, targetPose.Rotation(), true), m_constraints(constraints), m_poseSupplier(
+		poseSupplier), m_speedsSupplier(speedsSupplier), m_output(output), m_controller(
+		std::move(controller)), m_rotationDelayDistance(rotationDelayDistance), m_replanningConfig(
+		replanningConfig), m_shouldFlipPath([]() {
+	return false;
+}) {
 	AddRequirements(requirements);
 
 	Pathfinding::ensureInitialized();
@@ -89,7 +90,9 @@ void PathfindingCommand::Initialize() {
 		m_targetPose = frc::Pose2d(m_targetPath->getPoint(0).position,
 				m_goalEndState.getRotation());
 		if (m_shouldFlipPath()) {
-			m_targetPose = GeometryUtil::flipFieldPose(m_targetPose);
+			m_targetPose = GeometryUtil::flipFieldPose(m_originalTargetPose);
+			m_goalEndState = GoalEndState(m_goalEndState.getVelocity(),
+					m_targetPose.Rotation(), true);
 		}
 	}
 

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/commands/PathfindingCommand.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/commands/PathfindingCommand.h
@@ -86,6 +86,7 @@ private:
 	frc::Timer m_timer;
 	std::shared_ptr<PathPlannerPath> m_targetPath;
 	frc::Pose2d m_targetPose;
+	frc::Pose2d m_originalTargetPose;
 	GoalEndState m_goalEndState;
 	PathConstraints m_constraints;
 	std::function<frc::Pose2d()> m_poseSupplier;

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/controllers/PPHolonomicDriveController.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/controllers/PPHolonomicDriveController.h
@@ -105,7 +105,7 @@ private:
 	rpsPerMps_t m_mpsToRps;
 
 	frc::Translation2d m_translationError;
-	bool m_enabled;
+	bool m_enabled = true;
 
 	static std::function<std::optional<frc::Rotation2d>()> rotationTargetOverride;
 };


### PR DESCRIPTION
We are currently linking a Pathfind and Follow Path command to a button on our robot. We got it working great for the blue side of the field, but on the red side the Pathfinding would target the wrong angle. Once the actual follow path command started the heading got corrected properly. It seems like the heading issue was caused because m_goalEndState was not updated after m_targetPose was flipped. 

Regarding the idempotency issue, we noticed that using the command several times caused the heading to flip each time PathfindingCommand::Initialize was run, we just added a check so its only flipped once.