### PR TITLE
Add driver station warning if named command is not known

### DIFF
--- a/pathplannerlib-python/pathplannerlib/auto.py
+++ b/pathplannerlib-python/pathplannerlib/auto.py
@@ -9,7 +9,7 @@ from .commands import FollowPathRamsete, FollowPathHolonomic, FollowPathLTV, Pat
     PathfindThenFollowPathLTV
 from .geometry_util import flipFieldPose
 import os
-from wpilib import getDeployDirectory, reportError
+from wpilib import getDeployDirectory, reportError, reportWarning
 import json
 from commands2.command import Command
 from commands2.subsystem import Subsystem
@@ -51,6 +51,7 @@ class NamedCommands:
         if NamedCommands.hasCommand(name):
             return CommandUtil.wrappedEventCommand(NamedCommands._namedCommands[name])
         else:
+            reportWarning(f"PathPlanner attempted to create a command '{name}' that has not been registered with NamedCommands.registerCommand", False)
             return cmd.none()
 
 

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/auto/NamedCommands.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/auto/NamedCommands.java
@@ -1,6 +1,7 @@
 package com.pathplanner.lib.auto;
 
 import edu.wpi.first.math.Pair;
+import edu.wpi.first.wpilibj.DriverStation;
 import edu.wpi.first.wpilibj2.command.*;
 import java.util.HashMap;
 import java.util.List;
@@ -61,6 +62,11 @@ public class NamedCommands {
     if (hasCommand(name)) {
       return CommandUtil.wrappedEventCommand(namedCommands.get(name));
     } else {
+      DriverStation.reportWarning(
+          "PathPlanner attempted to create a command '"
+              + name
+              + "' that has not been registered with NamedCommands.registerCommand",
+          false);
       return Commands.none();
     }
   }

--- a/pathplannerlib/src/main/native/cpp/pathplanner/lib/auto/NamedCommands.cpp
+++ b/pathplannerlib/src/main/native/cpp/pathplanner/lib/auto/NamedCommands.cpp
@@ -1,5 +1,6 @@
 #include "pathplanner/lib/auto/NamedCommands.h"
 #include "pathplanner/lib/auto/CommandUtil.h"
+#include "frc/Errors.h"
 
 using namespace pathplanner;
 
@@ -10,5 +11,8 @@ frc2::CommandPtr NamedCommands::getCommand(std::string name) {
 		return CommandUtil::wrappedEventCommand(
 				NamedCommands::namedCommands.at(name));
 	}
+	FRC_ReportError(frc::warn::Warning,
+			"PathPlanner attempted to create a command '{}' that has not been registered with NamedCommands::registerCommand",
+			name);
 	return frc2::cmd::None();
 }


### PR DESCRIPTION
My kids had a capitalization problem with a named command and didn't know why their thing wasn't getting scheduled. By at least logging a warning, there is some insight to what is going wrong.

Alternatively, you can hard fail with an exception. I think it is bad that there can be a discrepancy that silently fails between what you see in the gui and what gets run on the robot.