### PR TITLE
Fix paths with events on C++

### DIFF
--- a/pathplannerlib/src/main/native/cpp/pathplanner/lib/commands/FollowPathCommand.cpp
+++ b/pathplannerlib/src/main/native/cpp/pathplanner/lib/commands/FollowPathCommand.cpp
@@ -68,9 +68,11 @@ void FollowPathCommand::Initialize() {
 	// Initialize marker stuff
 	m_currentEventCommands.clear();
 	m_untriggeredEvents.clear();
-	m_untriggeredEvents.insert(m_untriggeredEvents.end(),
-			m_generatedTrajectory.getEventCommands().begin(),
-			m_generatedTrajectory.getEventCommands().end());
+
+	const auto &eventCommands = m_generatedTrajectory.getEventCommands();
+
+	m_untriggeredEvents.insert(m_untriggeredEvents.end(), eventCommands.begin(),
+			eventCommands.end());
 
 	m_timer.Reset();
 	m_timer.Start();


### PR DESCRIPTION
The latest updates that changed event markers to be time based caused paths with events to crash on C++.  
When doing:
```
m_untriggeredEvents.insert(m_untriggeredEvents.end(),
  m_generatedTrajectory.getEventCommands().begin(),
  m_generatedTrajectory.getEventCommands().end());
```

A new vector is created each time m_generatedTrajectory.getEventCommands() is called, meaning that the iterators are not linked. I solved this by storing the eventCommands in a different variable and then getting the begin and end iterators from it. Another solution could maybe be changing PathPlannerTrajectory::getEventCommands to return a constant reference to the events.