### PR TITLE
Python Event Marker Requirements Matches Java

### DIFF
--- a/pathplannerlib-python/pathplannerlib/commands.py
+++ b/pathplannerlib-python/pathplannerlib/commands.py
@@ -59,13 +59,14 @@ class FollowPathCommand(Command):
         self._replanningConfig = replanning_config
         self._shouldFlipPath = should_flip_path
 
-        self.addRequirements(*requirements)
+        self.driveRequirements = requirements
+        self.addRequirements(*self.driveRequirements)
 
         for marker in self._originalPath.getEventMarkers():
             reqs = marker.command.getRequirements()
 
-            for req in self.getRequirements():
-                if req in reqs:
+            for req in reqs:
+                if req in self.driveRequirements:
                     raise RuntimeError(
                         'Events that are triggered during path following cannot require the drive subsystem')
 


### PR DESCRIPTION
Fixes #617 
When multiple event markers used the same subsystem, a RuntimeError is thrown, since the intake subsystem would be added into the current requirements, which tricked the code into believing it was a drive subsystem.