### PR TITLE
Altered Naming Convention for Duplicates

### DIFF
--- a/lib/pages/project/project_page.dart
+++ b/lib/pages/project/project_page.dart
@@ -889,9 +889,17 @@ class _ProjectPageState extends State<ProjectPage> {
         for (PathPlannerPath path in _paths) {
           pathNames.add(path.name);
         }
-        String pathName = 'Copy of ${_paths[i].name}';
+        String pathName = _paths[i].name;
+        RegExp exp = RegExp(r'\(\d+\)');
+        String source = pathName.substring(pathName.length-3);
         while (pathNames.contains(pathName)) {
-          pathName = 'Copy of $pathName';
+          if(exp.hasMatch(source)){
+            RegExpMatch? match = exp.firstMatch(source);
+            int index = int.parse(match![0]!.substring(1,2))+1; 
+            pathName = '${pathName.substring(0,pathName.length-3)}($index)'; 
+          } else{
+          pathName = '$pathName (1)';
+          }
         }
 
         setState(() {
@@ -1468,11 +1476,18 @@ class _ProjectPageState extends State<ProjectPage> {
         for (PathPlannerAuto auto in _autos) {
           autoNames.add(auto.name);
         }
-        String autoName = 'Copy of ${_autos[i].name}';
+        String autoName = _autos[i].name;
+        RegExp exp = RegExp(r'\(\d+\)');
+        String source = autoName.substring(autoName.length-3);
         while (autoNames.contains(autoName)) {
-          autoName = 'Copy of $autoName';
+          if(exp.hasMatch(source)){
+            RegExpMatch? match = exp.firstMatch(source);
+            int index = int.parse(match![0]!.substring(1,2))+1; 
+            autoName = '${autoName.substring(0,autoName.length-3)}($index)'; 
+          } else{
+          autoName = '$autoName (1)';
+          }
         }
-
         setState(() {
           _autos.add(_autos[i].duplicate(autoName));
           _sortAutos(_autoSortValue);

--- a/test/pages/project/project_page_test.dart
+++ b/test/pages/project/project_page_test.dart
@@ -372,7 +372,7 @@ void main() {
     await widgetTester.tap(find.text('Duplicate'));
     await widgetTester.pumpAndSettle();
 
-    expect(find.widgetWithText(ProjectItemCard, 'Copy of Example Path'),
+    expect(find.widgetWithText(ProjectItemCard, 'Example Path (1)'),
         findsOneWidget);
 
     await widgetTester.tap(menuButton);
@@ -381,7 +381,7 @@ void main() {
     await widgetTester.tap(find.text('Duplicate'));
     await widgetTester.pumpAndSettle();
 
-    expect(find.widgetWithText(ProjectItemCard, 'Copy of Copy of Example Path'),
+    expect(find.widgetWithText(ProjectItemCard, 'Example Path (2)'),
         findsOneWidget);
   });
 
@@ -436,7 +436,7 @@ void main() {
     await widgetTester.pumpAndSettle();
 
     expect(
-        find.widgetWithText(ProjectItemCard, 'Copy of auto1'), findsOneWidget);
+        find.widgetWithText(ProjectItemCard, 'auto1 (1)'), findsOneWidget);
 
     await widgetTester.tap(menuButton);
     await widgetTester.pumpAndSettle();
@@ -444,7 +444,7 @@ void main() {
     await widgetTester.tap(find.text('Duplicate'));
     await widgetTester.pumpAndSettle();
 
-    expect(find.widgetWithText(ProjectItemCard, 'Copy of Copy of auto1'),
+    expect(find.widgetWithText(ProjectItemCard, 'auto1 (2)'),
         findsOneWidget);
   });
 


### PR DESCRIPTION
In my experience the current naming convention of "Copy of {AutoName}" is very inconvenient, primarily when sorting the Path/Auto names alphabetically as duplicating an auto will send it to a random place in the stack instead of right next to the Path/Auto being duplicated. I believe the changes I've proposed would address this. 