### PR TITLE
Add a duplicate/copy button for each action in the autos on the PathPlanner client

### DIFF
--- a/lib/widgets/editor/tree_widgets/commands/command_group_widget.dart
+++ b/lib/widgets/editor/tree_widgets/commands/command_group_widget.dart
@@ -296,6 +296,17 @@ class CommandGroupWidget extends StatelessWidget {
   }
 
   void _duplicateCommand(int idx) {
-    // TODO: Duplicate command at index
+    undoStack.add(Change(
+      CommandGroup.cloneCommandsList(command.commands),
+      () {
+        Command commandToDuplicate = command.commands.elementAt(idx);
+        command.commands.insert(idx+1, commandToDuplicate);
+        onUpdated?.call();
+      },
+      (oldValue) {
+        command.commands = CommandGroup.cloneCommandsList(oldValue);
+        onUpdated?.call();
+      },
+    ));
   }
 }

--- a/lib/widgets/editor/tree_widgets/commands/command_group_widget.dart
+++ b/lib/widgets/editor/tree_widgets/commands/command_group_widget.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/material.dart';
-import 'package:flutter/widgets.dart';
 import 'package:pathplanner/commands/command.dart';
 import 'package:pathplanner/commands/command_groups.dart';
 import 'package:pathplanner/commands/named_command.dart';

--- a/lib/widgets/editor/tree_widgets/commands/command_group_widget.dart
+++ b/lib/widgets/editor/tree_widgets/commands/command_group_widget.dart
@@ -300,7 +300,7 @@ class CommandGroupWidget extends StatelessWidget {
     undoStack.add(Change(
       CommandGroup.cloneCommandsList(command.commands),
       () {
-        Command commandToDuplicate = command.commands.elementAt(idx);
+        Command commandToDuplicate = command.commands.elementAt(idx).clone();
         command.commands.insert(idx+1, commandToDuplicate);
         onUpdated?.call();
       },

--- a/lib/widgets/editor/tree_widgets/commands/command_group_widget.dart
+++ b/lib/widgets/editor/tree_widgets/commands/command_group_widget.dart
@@ -99,11 +99,6 @@ class CommandGroupWidget extends StatelessWidget {
               ),
             ),
             Expanded(child: Container()),
-            Visibility(
-                visible: removable,
-                child: DuplicateCommandButton(
-                  onPressed: onDuplicateCommand,
-                )),
             AddCommandButton(
               allowPathCommand: allPathNames != null,
               onTypeChosen: (value) {
@@ -120,6 +115,11 @@ class CommandGroupWidget extends StatelessWidget {
                 ));
               },
             ),
+            Visibility(
+                visible: removable,
+                child: DuplicateCommandButton(
+                  onPressed: onDuplicateCommand,
+                )),
             Visibility(
               visible: removable,
               child: Tooltip(

--- a/lib/widgets/editor/tree_widgets/commands/command_group_widget.dart
+++ b/lib/widgets/editor/tree_widgets/commands/command_group_widget.dart
@@ -1,4 +1,5 @@
 import 'package:flutter/material.dart';
+import 'package:flutter/widgets.dart';
 import 'package:pathplanner/commands/command.dart';
 import 'package:pathplanner/commands/command_groups.dart';
 import 'package:pathplanner/commands/named_command.dart';
@@ -6,6 +7,7 @@ import 'package:pathplanner/commands/path_command.dart';
 import 'package:pathplanner/commands/wait_command.dart';
 import 'package:pathplanner/widgets/conditional_widget.dart';
 import 'package:pathplanner/widgets/editor/tree_widgets/commands/add_command_button.dart';
+import 'package:pathplanner/widgets/editor/tree_widgets/commands/duplicate_command_button.dart';
 import 'package:pathplanner/widgets/editor/tree_widgets/commands/named_command_widget.dart';
 import 'package:pathplanner/widgets/editor/tree_widgets/commands/path_command_widget.dart';
 import 'package:pathplanner/widgets/editor/tree_widgets/commands/wait_command_widget.dart';
@@ -21,6 +23,7 @@ class CommandGroupWidget extends StatelessWidget {
   final List<String>? allPathNames;
   final ValueChanged<String?>? onPathCommandHovered;
   final ChangeStack undoStack;
+  final VoidCallback? onDuplicateCommand;
 
   const CommandGroupWidget({
     super.key,
@@ -33,6 +36,7 @@ class CommandGroupWidget extends StatelessWidget {
     this.allPathNames,
     this.onPathCommandHovered,
     required this.undoStack,
+    this.onDuplicateCommand,
   });
 
   @override
@@ -96,6 +100,12 @@ class CommandGroupWidget extends StatelessWidget {
               ),
             ),
             Expanded(child: Container()),
+            Visibility(
+              visible: removable,
+              child: DuplicateCommandButton(
+                  onPressed: onDuplicateCommand,
+              )
+            ),
             AddCommandButton(
               allowPathCommand: allPathNames != null,
               onTypeChosen: (value) {
@@ -262,6 +272,9 @@ class CommandGroupWidget extends StatelessWidget {
             },
           ));
         },
+        onDuplicateCommand: () {
+          _duplicateCommand(cmdIndex);
+        },
       );
     }
 
@@ -280,5 +293,9 @@ class CommandGroupWidget extends StatelessWidget {
         onUpdated?.call();
       },
     ));
+  }
+
+  void _duplicateCommand(int idx) {
+    // TODO: Duplicate command at index
   }
 }

--- a/lib/widgets/editor/tree_widgets/commands/command_group_widget.dart
+++ b/lib/widgets/editor/tree_widgets/commands/command_group_widget.dart
@@ -100,11 +100,10 @@ class CommandGroupWidget extends StatelessWidget {
             ),
             Expanded(child: Container()),
             Visibility(
-              visible: removable,
-              child: DuplicateCommandButton(
+                visible: removable,
+                child: DuplicateCommandButton(
                   onPressed: onDuplicateCommand,
-              )
-            ),
+                )),
             AddCommandButton(
               allowPathCommand: allPathNames != null,
               onTypeChosen: (value) {
@@ -300,7 +299,7 @@ class CommandGroupWidget extends StatelessWidget {
       CommandGroup.cloneCommandsList(command.commands),
       () {
         Command commandToDuplicate = command.commands.elementAt(idx).clone();
-        command.commands.insert(idx+1, commandToDuplicate);
+        command.commands.insert(idx + 1, commandToDuplicate);
         onUpdated?.call();
       },
       (oldValue) {

--- a/lib/widgets/editor/tree_widgets/commands/command_group_widget.dart
+++ b/lib/widgets/editor/tree_widgets/commands/command_group_widget.dart
@@ -177,6 +177,7 @@ class CommandGroupWidget extends StatelessWidget {
                         onUpdated: onUpdated,
                         onRemoved: () => _removeCommand(index),
                         undoStack: undoStack,
+                        onDuplicateCommand: () => _duplicateCommand(index),
                       ),
                     ),
                   ],
@@ -236,6 +237,7 @@ class CommandGroupWidget extends StatelessWidget {
         onUpdated: onUpdated,
         onRemoved: () => _removeCommand(cmdIndex),
         undoStack: undoStack,
+        onDuplicateCommand: () => _duplicateCommand(cmdIndex),
       );
     } else if (command.commands[cmdIndex] is WaitCommand) {
       return WaitCommandWidget(
@@ -243,6 +245,7 @@ class CommandGroupWidget extends StatelessWidget {
         onUpdated: onUpdated,
         onRemoved: () => _removeCommand(cmdIndex),
         undoStack: undoStack,
+        onDuplicateCommand: () => _duplicateCommand(cmdIndex),
       );
     } else if (command.commands[cmdIndex] is CommandGroup) {
       return CommandGroupWidget(
@@ -272,9 +275,7 @@ class CommandGroupWidget extends StatelessWidget {
             },
           ));
         },
-        onDuplicateCommand: () {
-          _duplicateCommand(cmdIndex);
-        },
+        onDuplicateCommand: () => _duplicateCommand(cmdIndex),
       );
     }
 

--- a/lib/widgets/editor/tree_widgets/commands/duplicate_command_button.dart
+++ b/lib/widgets/editor/tree_widgets/commands/duplicate_command_button.dart
@@ -1,0 +1,20 @@
+import 'package:flutter/material.dart';
+
+class DuplicateCommandButton extends StatelessWidget {
+  final VoidCallback? onPressed;
+  
+  const DuplicateCommandButton({
+    super.key,
+    this.onPressed
+  });
+
+  @override
+  Widget build(BuildContext context) {
+    ColorScheme colorScheme = Theme.of(context).colorScheme;
+
+    return IconButton(
+      onPressed: onPressed,
+      icon: Icon(Icons.copy, color: colorScheme.primary)
+    );
+  }
+}

--- a/lib/widgets/editor/tree_widgets/commands/duplicate_command_button.dart
+++ b/lib/widgets/editor/tree_widgets/commands/duplicate_command_button.dart
@@ -2,19 +2,15 @@ import 'package:flutter/material.dart';
 
 class DuplicateCommandButton extends StatelessWidget {
   final VoidCallback? onPressed;
-  
-  const DuplicateCommandButton({
-    super.key,
-    this.onPressed
-  });
+
+  const DuplicateCommandButton({super.key, this.onPressed});
 
   @override
   Widget build(BuildContext context) {
     ColorScheme colorScheme = Theme.of(context).colorScheme;
 
     return IconButton(
-      onPressed: onPressed,
-      icon: Icon(Icons.copy, color: colorScheme.primary)
-    );
+        onPressed: onPressed,
+        icon: Icon(Icons.copy, color: colorScheme.primary));
   }
 }

--- a/lib/widgets/editor/tree_widgets/commands/duplicate_command_button.dart
+++ b/lib/widgets/editor/tree_widgets/commands/duplicate_command_button.dart
@@ -11,6 +11,7 @@ class DuplicateCommandButton extends StatelessWidget {
 
     return IconButton(
         onPressed: onPressed,
+        tooltip: 'Duplicate',
         icon: Icon(Icons.copy, color: colorScheme.primary));
   }
 }

--- a/lib/widgets/editor/tree_widgets/commands/named_command_widget.dart
+++ b/lib/widgets/editor/tree_widgets/commands/named_command_widget.dart
@@ -1,6 +1,7 @@
 import 'package:flutter/material.dart';
 import 'package:pathplanner/commands/command.dart';
 import 'package:pathplanner/commands/named_command.dart';
+import 'package:pathplanner/widgets/editor/tree_widgets/commands/duplicate_command_button.dart';
 import 'package:undo/undo.dart';
 
 class NamedCommandWidget extends StatefulWidget {
@@ -8,6 +9,7 @@ class NamedCommandWidget extends StatefulWidget {
   final VoidCallback? onUpdated;
   final VoidCallback? onRemoved;
   final ChangeStack undoStack;
+  final VoidCallback? onDuplicateCommand;
 
   const NamedCommandWidget({
     super.key,
@@ -15,6 +17,7 @@ class NamedCommandWidget extends StatefulWidget {
     this.onUpdated,
     this.onRemoved,
     required this.undoStack,
+    this.onDuplicateCommand,
   });
 
   @override
@@ -99,6 +102,9 @@ class _NamedCommandWidgetState extends State<NamedCommandWidget> {
                   size: 32,
                 ),
               ),
+            ),
+            DuplicateCommandButton(
+              onPressed: widget.onDuplicateCommand,
             ),
             Tooltip(
               message: 'Remove Command',

--- a/lib/widgets/editor/tree_widgets/commands/path_command_widget.dart
+++ b/lib/widgets/editor/tree_widgets/commands/path_command_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:pathplanner/commands/path_command.dart';
+import 'package:pathplanner/widgets/editor/tree_widgets/commands/duplicate_command_button.dart';
 import 'package:undo/undo.dart';
 
 class PathCommandWidget extends StatefulWidget {
@@ -8,6 +9,7 @@ class PathCommandWidget extends StatefulWidget {
   final VoidCallback? onUpdated;
   final VoidCallback? onRemoved;
   final ChangeStack undoStack;
+  final VoidCallback? onDuplicateCommand;
 
   const PathCommandWidget({
     super.key,
@@ -16,6 +18,7 @@ class PathCommandWidget extends StatefulWidget {
     this.onUpdated,
     this.onRemoved,
     required this.undoStack,
+    this.onDuplicateCommand,
   });
 
   @override
@@ -91,6 +94,9 @@ class _PathCommandWidgetState extends State<PathCommandWidget> {
               size: 32,
             ),
           ),
+        ),
+        DuplicateCommandButton(
+          onPressed: widget.onDuplicateCommand,
         ),
         Tooltip(
           message: 'Remove Command',

--- a/lib/widgets/editor/tree_widgets/commands/wait_command_widget.dart
+++ b/lib/widgets/editor/tree_widgets/commands/wait_command_widget.dart
@@ -1,5 +1,6 @@
 import 'package:flutter/material.dart';
 import 'package:pathplanner/commands/wait_command.dart';
+import 'package:pathplanner/widgets/editor/tree_widgets/commands/duplicate_command_button.dart';
 import 'package:pathplanner/widgets/number_text_field.dart';
 import 'package:undo/undo.dart';
 
@@ -8,6 +9,7 @@ class WaitCommandWidget extends StatelessWidget {
   final VoidCallback? onUpdated;
   final VoidCallback? onRemoved;
   final ChangeStack undoStack;
+  final VoidCallback? onDuplicateCommand;
 
   const WaitCommandWidget({
     super.key,
@@ -15,6 +17,7 @@ class WaitCommandWidget extends StatelessWidget {
     this.onUpdated,
     this.onRemoved,
     required this.undoStack,
+    this.onDuplicateCommand,
   });
 
   @override
@@ -43,6 +46,9 @@ class WaitCommandWidget extends StatelessWidget {
               }
             },
           ),
+        ),
+        DuplicateCommandButton(
+          onPressed: onDuplicateCommand,
         ),
         const SizedBox(width: 8),
         Tooltip(


### PR DESCRIPTION
Create a button on the PathPlanner GUI to duplicate an action (a path, command, command group).

Implementation of https://github.com/mjansen4857/pathplanner/issues/652