### PR TITLE
Added buildAutoChooser to C++ lib

### DIFF
--- a/Writerside/topics/pplib-Build-an-Auto.md
+++ b/Writerside/topics/pplib-Build-an-Auto.md
@@ -440,12 +440,6 @@ class RobotContainer:
 
 ## Create a SendableChooser with all autos in project
 
-> **Note**
->
-> This feature is only available in the Java and Python versions of PathPlannerLib
->
-{style="note"}
-
 After configuring the AutoBuilder, you have the option to build a SendableChooser that is automatically populated with
 every auto in the project.
 
@@ -482,6 +476,41 @@ public class RobotContainer {
   public Command getAutonomousCommand() {
     return autoChooser.getSelected();
   }
+}
+```
+
+</tab>
+<tab title="C++" group-key="cpp">
+
+```C++
+#include <pathplanner/lib/auto/AutoBuilder.h>
+#include <frc/smartdashboard/SmartDashboard.h>
+#include <frc2/command/CommandPtr.h>
+#include <frc2/command/Command.h>
+#include <memory>
+
+using namespace pathplanner;
+
+RobotContainer::RobotContainer() {
+  // ...
+
+  // Build an auto chooser. This will use frc2::cmd::None() as the default option.
+  autoChooser = AutoBuilder::buildAutoChooser();
+
+  // Another option that allows you to specify the default auto by its name
+  // autoChooser = AutoBuilder::buildAutoChooser("My Default Auto");
+
+  frc::SmartDashboard::PutData("Auto Chooser", &autoChooser);
+}
+
+frc2::Command* RobotContainer::getAutonomousCommand() {
+  // Returns a frc2::Command* that is freed at program termination
+  return autoChooser.GetSelected();
+}
+
+frc2::CommandPtr RobotContainer::getAutonomousCommand() {
+  // Returns a copy that is freed after reference is lost
+  return frc2::CommandPtr(std::make_unique<frc2::Command>(*autoChooser.GetSelected()));
 }
 ```
 

--- a/pathplannerlib/src/main/native/cpp/pathplanner/lib/auto/AutoBuilder.cpp
+++ b/pathplannerlib/src/main/native/cpp/pathplanner/lib/auto/AutoBuilder.cpp
@@ -369,8 +369,7 @@ frc::SendableChooser<frc2::Command*> AutoBuilder::buildAutoChooser(std::string d
 
 	for(std::string const& entry : getAllAutoNames() )
 	{
-		pathplanner::PathPlannerAuto autoCommand(entry);
-		AutoBuilder::m_autoCommands.emplace_back(autoCommand);
+		AutoBuilder::m_autoCommands.emplace_back(pathplanner::PathPlannerAuto(entry).ToPtr());
 		if(defaultAutoName != "" && entry == defaultAutoName) {
 			foundDefaultOption = true;
 			chooser.SetDefaultOption(entry,m_autoCommands.back().get());
@@ -381,7 +380,7 @@ frc::SendableChooser<frc2::Command*> AutoBuilder::buildAutoChooser(std::string d
 
 	if(!foundDefaultOption)
 	{
-		AutoBuilder::m_autoCommand.emplace_back(frc2::cmd::None());
+		AutoBuilder::m_autoCommands.emplace_back(frc2::cmd::None());
 		chooser.SetDefaultOption("None",m_autoCommands.back().get());
 	}
 
@@ -395,7 +394,7 @@ std::vector<std::string> AutoBuilder::getAllAutoNames() {
 	if(!std::filesystem::directory_entry{autosPath}.exists())
 	{
 		FRC_ReportError(frc::err::Error,
-				"AutoBuilder could not locate the pathplanner autos directory")
+				"AutoBuilder could not locate the pathplanner autos directory");
 
 		return {};
 	}

--- a/pathplannerlib/src/main/native/cpp/pathplanner/lib/auto/AutoBuilder.cpp
+++ b/pathplannerlib/src/main/native/cpp/pathplanner/lib/auto/AutoBuilder.cpp
@@ -358,7 +358,7 @@ frc2::CommandPtr AutoBuilder::pathfindThenFollowPath(
 			pathfindingConstraints, rotationDelayDistance);
 }
 
-frc::SendableChooser<Command*> AutoBuilder::buildAutoChooser(std::string defaultAutoName) {
+frc::SendableChooser<frc2::Command*> AutoBuilder::buildAutoChooser(std::string defaultAutoName) {
 	if(!m_configured) {
 		throw std::runtime_error(
 				"AutoBuilder was not configured before attempting to build an auto chooser");
@@ -372,9 +372,8 @@ frc::SendableChooser<Command*> AutoBuilder::buildAutoChooser(std::string default
 		pathplanner::PathPlannerAuto autoCommand(entry);
 		AutoBuilder::m_autoCommands.emplace_back(autoCommand);
 		if(defaultAutoName != "" && entry == defaultAutoName) {
-			defaultOption = pathplanner::PathPlannerAuto(autoCommand)
+			defaultOption = autoCommand;
 			chooser.SetDefaultOption(entry,m_commands.back().get());
-			m_defaultCommandPosition = m_command.size() - 1;
 		} else {
 			chooser.AddOption(entry,m_commands.back().get());
 		}
@@ -384,7 +383,6 @@ frc::SendableChooser<Command*> AutoBuilder::buildAutoChooser(std::string default
 	{
 		AutoBuilder::m_autoCommand.emplace_back(frc2::cmd::None());
 		chooser.SetDefaultOption("None",m_commands.back().get());
-		m_defaultCommandPosition = m_command.size() - 1;
 	}
 
 	return chooser;
@@ -409,10 +407,10 @@ wpi::SmallVector<std::string> AutoBuilder::getAllAutoNames() {
 		if(!entry.is_regular_file()) { 
 			continue; 
 		}
-		if(!entry.path().extention() != ".auto") { 
+		if(entry.path().extention() != ".auto") { 
 			continue; 
 		}
-		autoPaths.emplace_back(entry.path().stem());
+		autoPathNames.emplace_back(entry.path().stem());
 	}
 
 	return autoPathNames;

--- a/pathplannerlib/src/main/native/cpp/pathplanner/lib/auto/AutoBuilder.cpp
+++ b/pathplannerlib/src/main/native/cpp/pathplanner/lib/auto/AutoBuilder.cpp
@@ -392,7 +392,7 @@ std::vector<std::string> AutoBuilder::getAllAutoNames() {
 	std::filesystem::path deployPath =  frc::filesystem::GetDeployDirectory();
 	std::filesystem::path autosPath = deployPath / "pathplanner/autos";
 
-	if(!std::filesystem::directory_entry{autos}.exists())
+	if(!std::filesystem::directory_entry{autosPath}.exists())
 	{
 		FRC_ReportError(frc::err::Error,
 				"AutoBuilder could not locate the pathplanner autos directory")
@@ -402,12 +402,12 @@ std::vector<std::string> AutoBuilder::getAllAutoNames() {
 	
 	std::vector<std::string> autoPathNames;
 
-	for(std::filesystem::directory_entry const& entry : std::filesystem::directory_iterator{autos})
+	for(std::filesystem::directory_entry const& entry : std::filesystem::directory_iterator{autosPath})
 	{
 		if(!entry.is_regular_file()) { 
 			continue; 
 		}
-		if(entry.path().extention() != ".auto") { 
+		if(entry.path().extension() != ".auto") { 
 			continue; 
 		}
 		autoPathNames.emplace_back(entry.path().stem());

--- a/pathplannerlib/src/main/native/cpp/pathplanner/lib/auto/AutoBuilder.cpp
+++ b/pathplannerlib/src/main/native/cpp/pathplanner/lib/auto/AutoBuilder.cpp
@@ -358,8 +358,9 @@ frc2::CommandPtr AutoBuilder::pathfindThenFollowPath(
 			pathfindingConstraints, rotationDelayDistance);
 }
 
-frc::SendableChooser<frc2::Command*> AutoBuilder::buildAutoChooser(std::string defaultAutoName) {
-	if(!m_configured) {
+frc::SendableChooser<frc2::Command*> AutoBuilder::buildAutoChooser(
+		std::string defaultAutoName) {
+	if (!m_configured) {
 		throw std::runtime_error(
 				"AutoBuilder was not configured before attempting to build an auto chooser");
 	}
@@ -367,47 +368,45 @@ frc::SendableChooser<frc2::Command*> AutoBuilder::buildAutoChooser(std::string d
 	frc::SendableChooser<frc2::Command*> chooser;
 	bool foundDefaultOption = false;
 
-	for(std::string const& entry : getAllAutoNames() )
-	{
-		AutoBuilder::m_autoCommands.emplace_back(pathplanner::PathPlannerAuto(entry).ToPtr());
-		if(defaultAutoName != "" && entry == defaultAutoName) {
+	for (std::string const &entry : getAllAutoNames()) {
+		AutoBuilder::m_autoCommands.emplace_back(
+				pathplanner::PathPlannerAuto(entry).ToPtr());
+		if (defaultAutoName != "" && entry == defaultAutoName) {
 			foundDefaultOption = true;
-			chooser.SetDefaultOption(entry,m_autoCommands.back().get());
+			chooser.SetDefaultOption(entry, m_autoCommands.back().get());
 		} else {
-			chooser.AddOption(entry,m_autoCommands.back().get());
+			chooser.AddOption(entry, m_autoCommands.back().get());
 		}
 	}
 
-	if(!foundDefaultOption)
-	{
+	if (!foundDefaultOption) {
 		AutoBuilder::m_autoCommands.emplace_back(frc2::cmd::None());
-		chooser.SetDefaultOption("None",m_autoCommands.back().get());
+		chooser.SetDefaultOption("None", m_autoCommands.back().get());
 	}
 
 	return chooser;
 }
 
 std::vector<std::string> AutoBuilder::getAllAutoNames() {
-	std::filesystem::path deployPath =  frc::filesystem::GetDeployDirectory();
+	std::filesystem::path deployPath = frc::filesystem::GetDeployDirectory();
 	std::filesystem::path autosPath = deployPath / "pathplanner/autos";
 
-	if(!std::filesystem::directory_entry{autosPath}.exists())
-	{
+	if (!std::filesystem::directory_entry { autosPath }.exists()) {
 		FRC_ReportError(frc::err::Error,
 				"AutoBuilder could not locate the pathplanner autos directory");
 
 		return {};
 	}
-	
-	std::vector<std::string> autoPathNames;
 
-	for(std::filesystem::directory_entry const& entry : std::filesystem::directory_iterator{autosPath})
-	{
-		if(!entry.is_regular_file()) { 
-			continue; 
+	std::vector < std::string > autoPathNames;
+
+	for (std::filesystem::directory_entry const &entry : std::filesystem::directory_iterator {
+			autosPath }) {
+		if (!entry.is_regular_file()) {
+			continue;
 		}
-		if(entry.path().extension() != ".auto") { 
-			continue; 
+		if (entry.path().extension() != ".auto") {
+			continue;
 		}
 		autoPathNames.emplace_back(entry.path().stem());
 	}

--- a/pathplannerlib/src/main/native/cpp/pathplanner/lib/auto/AutoBuilder.cpp
+++ b/pathplannerlib/src/main/native/cpp/pathplanner/lib/auto/AutoBuilder.cpp
@@ -405,10 +405,10 @@ std::vector<std::string> AutoBuilder::getAllAutoNames() {
 		if (!entry.is_regular_file()) {
 			continue;
 		}
-		if (entry.path().extension() != ".auto") {
+		if (entry.path().extension().string() != ".auto") {
 			continue;
 		}
-		autoPathNames.emplace_back(entry.path().stem());
+		autoPathNames.emplace_back(entry.path().stem().string());
 	}
 
 	return autoPathNames;

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/auto/AutoBuilder.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/auto/AutoBuilder.h
@@ -6,7 +6,7 @@
 #include <frc/geometry/Pose2d.h>
 #include <frc/kinematics/ChassisSpeeds.h>
 #include <frc/controller/RamseteController.h>
-#include <wpi/SmallVector.h>
+#include <vector>
 #include <frc2/command/Command.h>
 #include <frc/smartdashboard/SendableChooser.h>
 #include <memory>
@@ -271,7 +271,7 @@ public:
 	*
 	* @return vector of all auto names
 	*/
-	static wpi::SmallVector<std::string> getAllAutoNames();
+	static std::vector<std::string> getAllAutoNames();
 	
 private:
 	static bool m_configured;
@@ -280,7 +280,7 @@ private:
 	static std::function<void(frc::Pose2d)> m_resetPose;
 	static std::function<bool()> m_shouldFlipPath;
 
-	static wpi::SmallVector<frc2::CommandPtr,8> m_autoCommands;
+	static std::vector<frc2::CommandPtr> m_autoCommands;
 
 	static bool m_pathfindingConfigured;
 	static std::function<

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/auto/AutoBuilder.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/auto/AutoBuilder.h
@@ -255,24 +255,24 @@ public:
 			PathConstraints pathfindingConstraints,
 			units::meter_t rotationDelayDistance = 0_m);
 
+	/**
+	 * Create and populate a sendable chooser with all PathPlannerAutos in the project
+	 *
+	 * @param defaultAutoName The name of the auto that should be the default option. If this is an
+	 *     empty string, or if an auto with the given name does not exist, the default option will be
+	 *     frc2::cmd::None()
+	 * @return SendableChooser populated with all autos
+	 */
+	static frc::SendableChooser<frc2::Command*> buildAutoChooser(
+			std::string defaultAutoName = "");
 
 	/**
-	* Create and populate a sendable chooser with all PathPlannerAutos in the project
-	*
-	* @param defaultAutoName The name of the auto that should be the default option. If this is an
-	*     empty string, or if an auto with the given name does not exist, the default option will be
-	*     frc2::cmd::None()
-	* @return SendableChooser populated with all autos
-	*/
-	static frc::SendableChooser<frc2::Command*> buildAutoChooser(std::string defaultAutoName = "");
-
-	/**
-	* Get a vector of all auto names in the project
-	*
-	* @return vector of all auto names
-	*/
+	 * Get a vector of all auto names in the project
+	 *
+	 * @return vector of all auto names
+	 */
 	static std::vector<std::string> getAllAutoNames();
-	
+
 private:
 	static bool m_configured;
 	static std::function<frc2::CommandPtr(std::shared_ptr<PathPlannerPath>)> m_pathFollowingCommandBuilder;

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/auto/AutoBuilder.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/auto/AutoBuilder.h
@@ -264,7 +264,7 @@ public:
 	*     frc2::cmd::None()
 	* @return SendableChooser populated with all autos
 	*/
-	static frc::SendableChooser<Command*> buildAutoChooser(std::string defaultAutoName = "");
+	static frc::SendableChooser<frc2::Command*> buildAutoChooser(std::string defaultAutoName = "");
 
 	/**
 	* Get a vector of all auto names in the project
@@ -280,7 +280,7 @@ private:
 	static std::function<void(frc::Pose2d)> m_resetPose;
 	static std::function<bool()> m_shouldFlipPath;
 
-	static wpi::SmallVector<frc::CommandPtr,8> m_autoCommands;
+	static wpi::SmallVector<frc2::CommandPtr,8> m_autoCommands;
 
 	static bool m_pathfindingConfigured;
 	static std::function<

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/auto/AutoBuilder.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/auto/AutoBuilder.h
@@ -6,6 +6,9 @@
 #include <frc/geometry/Pose2d.h>
 #include <frc/kinematics/ChassisSpeeds.h>
 #include <frc/controller/RamseteController.h>
+#include <wpi/SmallVector.h>
+#include <frc2/command/Command.h>
+#include <frc/smartdashboard/SendableChooser.h>
 #include <memory>
 #include <wpi/json.h>
 #include <wpi/array.h>
@@ -252,12 +255,32 @@ public:
 			PathConstraints pathfindingConstraints,
 			units::meter_t rotationDelayDistance = 0_m);
 
+
+	/**
+	* Create and populate a sendable chooser with all PathPlannerAutos in the project
+	*
+	* @param defaultAutoName The name of the auto that should be the default option. If this is an
+	*     empty string, or if an auto with the given name does not exist, the default option will be
+	*     frc2::cmd::None()
+	* @return SendableChooser populated with all autos
+	*/
+	static frc::SendableChooser<Command*> buildAutoChooser(std::string defaultAutoName = "");
+
+	/**
+	* Get a vector of all auto names in the project
+	*
+	* @return vector of all auto names
+	*/
+	static wpi::SmallVector<std::string> getAllAutoNames();
+	
 private:
 	static bool m_configured;
 	static std::function<frc2::CommandPtr(std::shared_ptr<PathPlannerPath>)> m_pathFollowingCommandBuilder;
 	static std::function<frc::Pose2d()> m_getPose;
 	static std::function<void(frc::Pose2d)> m_resetPose;
 	static std::function<bool()> m_shouldFlipPath;
+
+	static wpi::SmallVector<frc::CommandPtr,8> m_autoCommands;
 
 	static bool m_pathfindingConfigured;
 	static std::function<


### PR DESCRIPTION
Added a equivalent version of buildAutoChooser for cpp from java.
Using the std::filesystem, we can inspect the files on the drive.
Since SendableChooser doesn't allow for rvalue storage, we need to store the commands ourselves so the user will not get a nullptr when trying to access a command* from GetSelected(). 