### PR TITLE
Add buildAutoChooserWithOptionsModifier 

### DIFF
--- a/Writerside/topics/pplib-Build-an-Auto.md
+++ b/Writerside/topics/pplib-Build-an-Auto.md
@@ -510,4 +510,43 @@ class RobotContainer:
 </tab>
 </tabs>
 
+## Create a SendableChooser with certain autos in project
+
+> **Note**
+>
+> This feature is only available in the Java version of PathPlannerLib
+>
+{style="note"}
+
+You can use the buildAutoChooserWithOptionsModifier method to process the 
+autos before they are shown on shuffle board
+
+```java
+public class RobotContainer {
+  private final SendableChooser<Command> autoChooser;
+
+  public RobotContainer() {
+    // ...
+
+    // Check if currently attached to the FMS
+    boolean isCompetition = DriverStation.isFMSAttached();
+    
+    // Build an auto chooser. This will use Commands.none() as the default option.
+    // As an example, this will only show autos that start with "comp" while
+    // currently attached to FMS
+    autoChooser = AutoBuilder.buildAutoChooserWithOptionsModifier(
+      (stream) -> isCompetition
+        ? stream.filter(auto -> auto.getName().startsWith("comp")) 
+        : stream
+    );
+
+    SmartDashboard.putData("Auto Chooser", autoChooser);
+  }
+
+  public Command getAutonomousCommand() {
+    return autoChooser.getSelected();
+  }
+}
+```
+
 </snippet>

--- a/Writerside/topics/pplib-Build-an-Auto.md
+++ b/Writerside/topics/pplib-Build-an-Auto.md
@@ -521,6 +521,14 @@ class RobotContainer:
 You can use the buildAutoChooserWithOptionsModifier method to process the 
 autos before they are shown on shuffle board
 
+> **Warning**
+>
+> Be careful using runtime values when generating AutoChooser, as RobotContainer is 
+> built at robot code startup. Things like FMS values may not be present at startup
+>
+{style="warning"}
+
+
 ```java
 public class RobotContainer {
   private final SendableChooser<Command> autoChooser;
@@ -528,12 +536,12 @@ public class RobotContainer {
   public RobotContainer() {
     // ...
 
-    // Check if currently attached to the FMS
-    boolean isCompetition = DriverStation.isFMSAttached();
+    // For convenience a programmer could change this when going to competition.
+    boolean isCompetition = true;
     
     // Build an auto chooser. This will use Commands.none() as the default option.
-    // As an example, this will only show autos that start with "comp" while
-    // currently attached to FMS
+    // As an example, this will only show autos that start with "comp" while at
+    // competition as defined by the programmer
     autoChooser = AutoBuilder.buildAutoChooserWithOptionsModifier(
       (stream) -> isCompetition
         ? stream.filter(auto -> auto.getName().startsWith("comp")) 

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/auto/AutoBuilder.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/auto/AutoBuilder.java
@@ -657,7 +657,7 @@ public class AutoBuilder {
   public static SendableChooser<Command> buildAutoChooser() {
     return buildAutoChooser("");
   }
-
+  
   /**
    * Create and populate a sendable chooser with all PathPlannerAutos in the project
    *
@@ -667,6 +667,38 @@ public class AutoBuilder {
    * @return SendableChooser populated with all autos
    */
   public static SendableChooser<Command> buildAutoChooser(String defaultAutoName) {
+    return buildAutoChooserWithOptionsModifier(defaultAutoName, (stream) -> stream);
+  }
+
+  /**
+   * Create and populate a sendable chooser with all PathPlannerAutos in the project. The default
+   * option will be Commands.none()
+   * 
+   * @param optionsModifier A lambda function that can be used to modify the options before they go
+   *     into the AutoChooser
+   * 
+   * @return SendableChooser populated with all autos
+   */
+  public static SendableChooser<Command> buildAutoChooserWithOptionsModifier(
+    Function<Stream<PathPlannerAuto>, Stream<PathPlannerAuto>> optionsModifier
+  ) {
+    return buildAutoChooserWithOptionsModifier("", optionsModifier);
+  }
+  
+  /**
+   * Create and populate a sendable chooser with all PathPlannerAutos in the project
+   *
+   * @param defaultAutoName The name of the auto that should be the default option. If this is an
+   *     empty string, or if an auto with the given name does not exist, the default option will be
+   *     Commands.none()
+   * @param optionsModifier A lambda function that can be used to modify the options before they go
+   *     into the AutoChooser
+   * @return SendableChooser populated with all autos
+   */
+  public static SendableChooser<Command> buildAutoChooserWithOptionsModifier(
+      String defaultAutoName, 
+      Function<Stream<PathPlannerAuto>, Stream<PathPlannerAuto>> optionsModifier
+    ) {
     if (!AutoBuilder.isConfigured()) {
       throw new RuntimeException(
           "AutoBuilder was not configured before attempting to build an auto chooser");
@@ -694,7 +726,7 @@ public class AutoBuilder {
       chooser.setDefaultOption(defaultOption.getName(), defaultOption);
     }
 
-    options.forEach(auto -> chooser.addOption(auto.getName(), auto));
+    optionsModifier.apply(options.stream()).forEach(auto -> chooser.addOption(auto.getName(), auto));
 
     return chooser;
   }

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/auto/AutoBuilder.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/auto/AutoBuilder.java
@@ -657,7 +657,7 @@ public class AutoBuilder {
   public static SendableChooser<Command> buildAutoChooser() {
     return buildAutoChooser("");
   }
-  
+
   /**
    * Create and populate a sendable chooser with all PathPlannerAutos in the project
    *
@@ -673,18 +673,16 @@ public class AutoBuilder {
   /**
    * Create and populate a sendable chooser with all PathPlannerAutos in the project. The default
    * option will be Commands.none()
-   * 
+   *
    * @param optionsModifier A lambda function that can be used to modify the options before they go
    *     into the AutoChooser
-   * 
    * @return SendableChooser populated with all autos
    */
   public static SendableChooser<Command> buildAutoChooserWithOptionsModifier(
-    Function<Stream<PathPlannerAuto>, Stream<PathPlannerAuto>> optionsModifier
-  ) {
+      Function<Stream<PathPlannerAuto>, Stream<PathPlannerAuto>> optionsModifier) {
     return buildAutoChooserWithOptionsModifier("", optionsModifier);
   }
-  
+
   /**
    * Create and populate a sendable chooser with all PathPlannerAutos in the project
    *
@@ -696,9 +694,8 @@ public class AutoBuilder {
    * @return SendableChooser populated with all autos
    */
   public static SendableChooser<Command> buildAutoChooserWithOptionsModifier(
-      String defaultAutoName, 
-      Function<Stream<PathPlannerAuto>, Stream<PathPlannerAuto>> optionsModifier
-    ) {
+      String defaultAutoName,
+      Function<Stream<PathPlannerAuto>, Stream<PathPlannerAuto>> optionsModifier) {
     if (!AutoBuilder.isConfigured()) {
       throw new RuntimeException(
           "AutoBuilder was not configured before attempting to build an auto chooser");
@@ -726,7 +723,9 @@ public class AutoBuilder {
       chooser.setDefaultOption(defaultOption.getName(), defaultOption);
     }
 
-    optionsModifier.apply(options.stream()).forEach(auto -> chooser.addOption(auto.getName(), auto));
+    optionsModifier
+        .apply(options.stream())
+        .forEach(auto -> chooser.addOption(auto.getName(), auto));
 
     return chooser;
   }


### PR DESCRIPTION
I created a new method called `buildAutoChooserWithOptionsModifier`, that accepts a second parameter in the form of a lambda function that takes in a stream and returns a stream of PathPlannerAutos.

I also added documentation to filter these options based on if they included the text "comp" at the beginning of the name. Some other examples you could do would be override the name with `.setName`, filter depending on if you're red or blue, or use [`.sorted()`](https://docs.oracle.com/javase/8/docs/api/java/util/stream/Stream.html#sorted--) on the stream to sort them arbitrarily before going on shuffle board.

I couldn't run spotless for some weird errors in my environment I need to figure out but the formatting should be good enough. I also manually wrote that documentation so no guarantees it actually works with Writerside 🤷.

P.S. pathplanners great, thanks for all the work you do :)