### PR TITLE
Fix typo

### DIFF
--- a/pathplannerlib/src/main/java/com/pathplanner/lib/commands/PathPlannerAuto.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/commands/PathPlannerAuto.java
@@ -51,7 +51,7 @@ public class PathPlannerAuto extends Command {
    * @param autoName Name of the auto to get the pose from
    * @return Starting pose from the given auto
    */
-  public static Pose2d getStaringPoseFromAutoFile(String autoName) {
+  public static Pose2d getStartingPoseFromAutoFile(String autoName) {
     try (BufferedReader br =
         new BufferedReader(
             new FileReader(


### PR DESCRIPTION
Noticed a small typo in the name of the method to get the starting pose from an auto file. This change will make it so the naming of the method reflects the naming in the docs.