### PR TITLE
Replicate fix in commit: fa5020b for python lib (pathfinding starting…

### DIFF
--- a/pathplannerlib-python/pathplannerlib/commands.py
+++ b/pathplannerlib-python/pathplannerlib/commands.py
@@ -286,6 +286,8 @@ class PathfindingCommand(Command):
 
     _timeOffset: float = 0
 
+    _finish: bool = False
+
     _instances: int = 0
 
     def __init__(self, constraints: PathConstraints, pose_supplier: Callable[[], Pose2d],
@@ -341,6 +343,7 @@ class PathfindingCommand(Command):
     def initialize(self):
         self._currentTrajectory = None
         self._timeOffset = 0.0
+        self._finish = False
 
         currentPose = self._poseSupplier()
 
@@ -355,7 +358,7 @@ class PathfindingCommand(Command):
 
         if currentPose.translation().distance(self._targetPose.translation()) < 0.5:
             self._output(ChassisSpeeds())
-            self.cancel()
+            self._finish = True
         else:
             Pathfinding.setStartPosition(currentPose.translation())
             Pathfinding.setGoalPosition(self._targetPose.translation())
@@ -363,6 +366,9 @@ class PathfindingCommand(Command):
         self._startingPose = currentPose
 
     def execute(self):
+        if self._finish:
+            return
+        
         currentPose = self._poseSupplier()
         currentSpeeds = self._speedsSupplier()
 
@@ -475,6 +481,9 @@ class PathfindingCommand(Command):
             self._output(targetSpeeds)
 
     def isFinished(self) -> bool:
+        if self._finish:
+            return True
+
         if self._targetPath is not None and not self._targetPath.isChoreoPath():
             currentPose = self._poseSupplier()
             currentSpeeds = self._speedsSupplier()


### PR DESCRIPTION
… from/near goal position)

When migrating current season comp robot from Java to Python, we discovered in testing that the fix in this commit (https://github.com/mjansen4857/pathplanner/commit/fa5020b2fbc229bc87ea5ee1a0a9043a3744cd24) has not been ported over. (Note: we have not looked at any other newer commits to the main lib since the last python lib updates ... just this one that affects us directly in our autos).