### PR TITLE
Update Trajectory State to support Choreo moduleForces

### DIFF
--- a/pathplannerlib/src/main/java/com/pathplanner/lib/path/PathPlannerPath.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/path/PathPlannerPath.java
@@ -326,7 +326,18 @@ public class PathPlannerPath {
         double xVel = ((Number) sample.get("velocityX")).doubleValue();
         double yVel = ((Number) sample.get("velocityY")).doubleValue();
         double angularVelRps = ((Number) sample.get("angularVelocity")).doubleValue();
-
+        JSONArray moduleForcesXArray = (JSONArray) sample.get("moduleForcesX");
+        List<Double> moduleForcesX = new ArrayList<>();
+        for (Object force : moduleForcesXArray) {
+          moduleForcesX.add(((Number) force).doubleValue());
+        }
+        state.moduleForcesX = Optional.of(moduleForcesX);
+        JSONArray moduleForcesYArray = (JSONArray) sample.get("moduleForcesY");
+        List<Double> moduleForcesY = new ArrayList<>();
+        for (Object force : moduleForcesYArray) {
+          moduleForcesY.add(((Number) force).doubleValue());
+        }
+        state.moduleForcesY = Optional.of(moduleForcesY);
         state.timeSeconds = time;
         state.linearVelocity = Math.hypot(xVel, yVel);
         state.pose = new Pose2d(new Translation2d(xPos, yPos), new Rotation2d(rotationRad));

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/trajectory/PathPlannerTrajectoryState.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/trajectory/PathPlannerTrajectoryState.java
@@ -1,5 +1,8 @@
 package com.pathplanner.lib.trajectory;
 
+import java.util.List;
+import java.util.Optional;
+
 import com.pathplanner.lib.path.PathConstraints;
 import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.geometry.Pose2d;
@@ -17,7 +20,10 @@ public class PathPlannerTrajectoryState {
   public Pose2d pose = Pose2d.kZero;
   /** The linear velocity at this state in m/s */
   public double linearVelocity = 0.0;
-
+  /** Optional module forces in the X direction in N on each module. Module forces appear in the following order: [FL, FR, BL, BR]. Will only be provided for Choreo paths*/
+  public Optional<List<Double>> moduleForcesX = Optional.empty();
+  /** Optional module forces in the Y direction in N on each module. Module forces appear in the following order: [FL, FR, BL, BR]. Will only be provided for Choreo paths*/
+  public Optional<List<Double>> moduleForcesY = Optional.empty();
   // Values used only during generation, these will not be interpolated
   /** The field-relative heading, or direction of travel, at this state */
   protected Rotation2d heading = Rotation2d.kZero;


### PR DESCRIPTION
As seen in [Choreo's new TrajectoryState](https://sleipnirgroup.github.io/Choreo/api/choreolib/java/com/choreo/lib/ChoreoTrajectoryState.html), moduleForces are pre-calculated. 
This exposes those moduleForces, and updates the PathPlannerPath to make that possible.