### PR TITLE
Style changes to buildAutoChooser

### DIFF
--- a/Writerside/topics/pplib-Build-an-Auto.md
+++ b/Writerside/topics/pplib-Build-an-Auto.md
@@ -540,33 +540,29 @@ RobotContainer::RobotContainer() {
   // Build an auto chooser. This will use frc2::cmd::None() as the default option.
   // As an example, this will only show autos that start with "comp" while at
   // competition as defined by the programmer
-  autoChooser = AutoBuilder::buildAutoChooser(
-    "", // If empty it will choose frc2::cmd::None()
-    [&isCompetition](const PathPlannerAuto *const autoCommand,
-            std::filesystem::path autoPath)
+  autoChooser = AutoBuilder::buildAutoChooserFilter(
+    [&isCompetition](const PathPlannerAuto& autoCommand)
     {
-      return isCompetition ? autoCommand->GetName().starts_with("comp") : true;
+      return isCompetition ? autoCommand.GetName().starts_with("comp") : true;
     }
   );
 
   // Another option that allows you to specify the default auto by its name
   /*
-  autoChooser = AutoBuilder::buildAutoChooser(
-    "autoDefault", // If filled it will choosen always, regardless of filter
-    [&isCompetition](const PathPlannerAuto *const autoCommand,
-            std::filesystem::path autoP)
+  autoChooser = AutoBuilder::buildAutoChooserFilter(
+    [&isCompetition](const PathPlannerAuto& autoCommand)
     {
-      return isCompetition ? autoCommand->GetName().starts_with("comp") : true;
-    }
+      return isCompetition ? autoCommand.GetName().starts_with("comp") : true;
+    },
+    "autoDefault", // If filled it will choosen always, regardless of filter
   ); 
   */
 
   // Another option allows you to filter out current directories relative to pathplanner/auto deploy directory
   // Allows only autos in directory deploy/pathplanner/autos/comp
   /*
-  autoChooser = AutoBuilder::buildAutoChooser(
-    "",
-    [&isCompetition](const PathPlannerAuto *const autoCommand,
+  autoChooser = AutoBuilder::buildAutoChooserFilterPathFilterPath(
+    [&isCompetition](const PathPlannerAuto&  autoCommand,
             std::filesystem::path autoPath)
     {
       return isCompetition ? autoPath.compare("comp") > 0 : true;

--- a/Writerside/topics/pplib-Build-an-Auto.md
+++ b/Writerside/topics/pplib-Build-an-Auto.md
@@ -558,7 +558,7 @@ RobotContainer::RobotContainer() {
   ); 
   */
 
-  // Another option allows you to filter out current directories relative to pathplanner/auto deploy directory
+  // Another option allows you to filter out current directories relative to deploy/pathplanner/auto directory
   // Allows only autos in directory deploy/pathplanner/autos/comp
   /*
   autoChooser = AutoBuilder::buildAutoChooserFilterPathFilterPath(

--- a/pathplannerlib/src/main/native/cpp/pathplanner/lib/auto/AutoBuilder.cpp
+++ b/pathplannerlib/src/main/native/cpp/pathplanner/lib/auto/AutoBuilder.cpp
@@ -158,8 +158,27 @@ void AutoBuilder::regenerateSendableReferences() {
 }
 
 frc::SendableChooser<frc2::Command*> AutoBuilder::buildAutoChooser(
-		std::string defaultAutoName,
-		std::function<bool(const PathPlannerAuto* const, std::filesystem::path)> filter) {
+		std::string defaultAutoName) {
+	return buildAutoChooserFilterPath(
+			[](const PathPlannerAuto &autoCommand,
+					std::filesystem::path autoPath) {
+				return true;
+			},defaultAutoName);
+}
+
+frc::SendableChooser<frc2::Command*> AutoBuilder::buildAutoChooserFilter(
+		std::function<bool(const PathPlannerAuto&)> filter,
+		std::string defaultAutoName) {
+	return buildAutoChooserFilterPath(
+			[&filter](const PathPlannerAuto &autoCommand,
+					std::filesystem::path autoPath) {
+				return filter(autoCommand);
+			},defaultAutoName);
+}
+
+frc::SendableChooser<frc2::Command*> AutoBuilder::buildAutoChooserFilterPath(
+		std::function<bool(const PathPlannerAuto&, std::filesystem::path)> filter,
+		std::string defaultAutoName) {
 	if (!m_configured) {
 		throw std::runtime_error(
 				"AutoBuilder was not configured before attempting to build an auto chooser");
@@ -180,8 +199,7 @@ frc::SendableChooser<frc2::Command*> AutoBuilder::buildAutoChooser(
 		if (defaultAutoName == autoName) {
 			sendableChooser.SetDefaultOption(autoName, entry.second.get());
 			defaultSelected = true;
-		} else if (filter(
-				dynamic_cast<const PathPlannerAuto* const >(entry.second.get()),
+		} else if (filter(*static_cast<PathPlannerAuto*>(entry.second.get()),
 				entry.first)) {
 			sendableChooser.AddOption(autoName, entry.second.get());
 		}

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/auto/AutoBuilder.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/auto/AutoBuilder.h
@@ -207,31 +207,58 @@ public:
 	/**
 	 * Modifies the existing references that buildAutoChooser returns in SendableChooser to the most recent in the pathplanner/auto deploy directory
 	 * 
+	 * Loads PathPlannerAutos from deploy/pathplanner/auto directory (recurively) on every call
 	 * Adds new auto paths from the pathplanner/auto deploy directory however doesn't remove autos already previously loaded
 	 */
 
 	static void regenerateSendableReferences();
 
 	/**
-	 * Create and populate a sendable chooser with all PathPlannerAutos in the project in pathplanner/auto deploy directory (recurively)
+	 * Populate a sendable chooser with all loaded PathPlannerAutos in the project in pathplanner/auto deploy directory (recurively)
+	 * Loads PathPlannerAutos from deploy/pathplanner/auto directory (recurively) on first call
 	 *
 	 * @param defaultAutoName The name of the auto that should be the default option. If this is an
 	 *     empty string, or if an auto with the given name does not exist, the default option will be
-	 *     frc2::cmd::None(), defaultAutoName doesn't get filter out and always is in final sendable chooser
-	 * @param filter Function which filters the auto commands out, returning true allows the command to be uploaded to sendable chooser 
-	 * 		while returning false prevents it from being added. 
-	 * 		First param: autoCommand, pointer to PathPlannerAuto command which was generated
-	 * 		Second param: autoPath, path to the autoCommand relative to pathplanner/auto deploy directory with extension ".auto"
+	 *     frc2::cmd::None()
 	 * @return SendableChooser populated with all autos
 	 */
 	static frc::SendableChooser<frc2::Command*> buildAutoChooser(
-			std::string defaultAutoName = "",
-			std::function<
-					bool(const PathPlannerAuto* const, std::filesystem::path)> filter =
-					[](const PathPlannerAuto *const autoCommand,
-							std::filesystem::path autoPath) {
-						return true;
-					});
+			std::string defaultAutoName = "");
+
+	/**
+	 * Populate a sendable chooser with all loaded PathPlannerAutos in the project in pathplanner/auto deploy directory (recurively)
+	 * Loads PathPlannerAutos from deploy/pathplanner/auto directory (recurively) on first call
+	 * Filters certain PathPlannerAuto bases on their properties
+	 *
+	 * @param filter Function which filters the auto commands out, returning true allows the command to be uploaded to sendable chooser 
+	 * 		while returning false prevents it from being added. 
+	 * 		autoCommand, const reference to PathPlannerAuto command which was generated
+	 * @param defaultAutoName The name of the auto that should be the default option. If this is an
+	 *     empty string, or if an auto with the given name does not exist, the default option will be
+	 *     frc2::cmd::None(), defaultAutoName doesn't get filter out and always is in final sendable chooser (if found)
+	 * @return SendableChooser populated with all autos
+	 */
+	static frc::SendableChooser<frc2::Command*> buildAutoChooserFilter(
+			std::function<bool(const PathPlannerAuto&)> filter,
+			std::string defaultAutoName = "");
+
+	/**
+	 * Populate a sendable chooser with all loaded PathPlannerAutos in the project in pathplanner/auto deploy directory (recurively)
+	 * Loads PathPlannerAutos from deploy/pathplanner/auto directory (recurively) on first call
+	 * Filters certain PathPlannerAuto bases on their properties and their filepath
+	 *
+	 * @param filter Function which filters the auto commands out, returning true allows the command to be uploaded to sendable chooser 
+	 * 		while returning false prevents it from being added. 
+	 * 		autoCommand, const reference to PathPlannerAuto command which was generated
+	 * 		autoPath, path to the autoCommand relative to pathplanner/auto deploy directory with extension ".auto"
+	 * @param defaultAutoName The name of the auto that should be the default option. If this is an
+	 *     empty string, or if an auto with the given name does not exist, the default option will be
+	 *     frc2::cmd::None(), defaultAutoName doesn't get filter out and always is in final sendable chooser (if found)
+	 * @return SendableChooser populated with all autos
+	 */
+	static frc::SendableChooser<frc2::Command*> buildAutoChooserFilterPath(
+			std::function<bool(const PathPlannerAuto&, std::filesystem::path)> filter,
+			std::string defaultAutoName = "");
 
 	/**
 	 * Get a vector of all auto names in the pathplanner/auto deploy directory (recurively)

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/auto/AutoBuilder.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/auto/AutoBuilder.h
@@ -207,15 +207,15 @@ public:
 	/**
 	 * Modifies the existing references that buildAutoChooser returns in SendableChooser to the most recent in the pathplanner/auto deploy directory
 	 * 
-	 * Loads PathPlannerAutos from deploy/pathplanner/auto directory (recurively) on every call
+	 * Loads PathPlannerAutos from deploy/pathplanner/auto directory (recursively) on every call
 	 * Adds new auto paths from the pathplanner/auto deploy directory however doesn't remove autos already previously loaded
 	 */
 
 	static void regenerateSendableReferences();
 
 	/**
-	 * Populate a sendable chooser with all loaded PathPlannerAutos in the project in pathplanner/auto deploy directory (recurively)
-	 * Loads PathPlannerAutos from deploy/pathplanner/auto directory (recurively) on first call
+	 * Populate a sendable chooser with all loaded PathPlannerAutos in the project in pathplanner/auto deploy directory (recursively)
+	 * Loads PathPlannerAutos from deploy/pathplanner/auto directory (recursively) on first call
 	 *
 	 * @param defaultAutoName The name of the auto that should be the default option. If this is an
 	 *     empty string, or if an auto with the given name does not exist, the default option will be
@@ -226,8 +226,8 @@ public:
 			std::string defaultAutoName = "");
 
 	/**
-	 * Populate a sendable chooser with all loaded PathPlannerAutos in the project in pathplanner/auto deploy directory (recurively)
-	 * Loads PathPlannerAutos from deploy/pathplanner/auto directory (recurively) on first call
+	 * Populate a sendable chooser with all loaded PathPlannerAutos in the project in pathplanner/auto deploy directory (recursively)
+	 * Loads PathPlannerAutos from deploy/pathplanner/auto directory (recursively) on first call
 	 * Filters certain PathPlannerAuto bases on their properties
 	 *
 	 * @param filter Function which filters the auto commands out, returning true allows the command to be uploaded to sendable chooser 
@@ -243,8 +243,8 @@ public:
 			std::string defaultAutoName = "");
 
 	/**
-	 * Populate a sendable chooser with all loaded PathPlannerAutos in the project in pathplanner/auto deploy directory (recurively)
-	 * Loads PathPlannerAutos from deploy/pathplanner/auto directory (recurively) on first call
+	 * Populate a sendable chooser with all loaded PathPlannerAutos in the project in pathplanner/auto deploy directory (recursively)
+	 * Loads PathPlannerAutos from deploy/pathplanner/auto directory (recursively) on first call
 	 * Filters certain PathPlannerAuto bases on their properties and their filepath
 	 *
 	 * @param filter Function which filters the auto commands out, returning true allows the command to be uploaded to sendable chooser 
@@ -261,14 +261,14 @@ public:
 			std::string defaultAutoName = "");
 
 	/**
-	 * Get a vector of all auto names in the pathplanner/auto deploy directory (recurively)
+	 * Get a vector of all auto names in the pathplanner/auto deploy directory (recursively)
 	 *
 	 * @return Vector of strings containing all auto names
 	 */
 	static std::vector<std::string> getAllAutoNames();
 
 	/**
-	 * Get a vector of all auto paths in the pathplanner/auto deploy directory (recurively)
+	 * Get a vector of all auto paths in the pathplanner/auto deploy directory (recursively)
 	 * 
 	 * @return Vector of paths relative to autos deploy directory
 	 */


### PR DESCRIPTION
Changed filtering function from `const PathPlannerAuto* const`-> `const PathPlannerAuto&`: Easier syntax, reference act like varible instead of pointer
`const_cast<>` can still change the const-ness of `PathPlannerAuto&` which allows them to edit directly (I despise this feature, however there is no copy constructor for `PathPlannerAuto` due to `unique_ptr`)
Replace `dynamic_cast<>` to `static_cast<>` since we know relationship at compile time 
Set `filter` as first parameter and `defaultAutoName` as second (which is defaulted), which prevents confusion as to why there is an empty string input (in user code)
Separated `buildAutoChooser` into `buildAutoChooser`, `buildAutoChooserFilter`, and `buildAutoChooserFilterPath` for different degrees of concern and to mirror java version more neatly (allows people to change from both languages)
Updated function descriptions

Degrees of concern for `buildAutoChooser`
* Person who just wants to get a `SendableChooser` of all PathPlannerAutos just needs to worry about `buildAutoChooser`
* Person who wants to `filter` out some PathPlannerAutos just needs to worry about `buildAutoChooserFilter`
* Person who wants to `filter` out some PathPlannerAutos based on filepath (`std::filesystem::path` libary) needs to worry about `buildAutoChooserFilterPath` 

I know I have made a lot of changes to this feature however I just want it to be right before backward compatibility requirements happen. I am probably not going to edit this any further as it performs all the roles it need to Java version while maintaining C++ style.
Good luck rolling out for the 2025 season btw👍