### PR TITLE
Make documentation Autobuilder example match the project example for C++

### DIFF
--- a/Writerside/topics/pplib-Build-an-Auto.md
+++ b/Writerside/topics/pplib-Build-an-Auto.md
@@ -109,7 +109,7 @@ SwerveSubsystem::SwerveSubsystem(){
         [this](frc::Pose2d pose){ resetPose(pose); }, // Method to reset odometry (will be called if your auto has a starting pose)
         [this](){ return getRobotRelativeSpeeds(); }, // ChassisSpeeds supplier. MUST BE ROBOT RELATIVE
         [this](auto speeds, auto feedforwards){ driveRobotRelative(speeds); }, // Method that will drive the robot given ROBOT RELATIVE ChassisSpeeds. Also optionally outputs individual module feedforwards
-        PPHolonomicDriveController( // PPHolonomicController is the built in path following controller for holonomic drive trains
+        std::make_shared<PPHolonomicDriveController>( // PPHolonomicController is the built in path following controller for holonomic drive trains
             PIDConstants(5.0, 0.0, 0.0), // Translation PID constants
             PIDConstants(5.0, 0.0, 0.0) // Rotation PID constants
         ),


### PR DESCRIPTION
The Autobuilder example in the [documentation](https://pathplanner.dev/pplib-getting-started.html#install-pathplannerlib) did not match the [project example](https://github.com/mjansen4857/pathplanner/blob/main/examples/cpp/src/main/cpp/subsystems/SwerveSubsystem.cpp) for C++.