### PR TITLE
Switch C++ AutoBuilder `std::function`s to accept `const&`

### DIFF
--- a/examples/cpp/src/main/cpp/subsystems/SwerveSubsystem.cpp
+++ b/examples/cpp/src/main/cpp/subsystems/SwerveSubsystem.cpp
@@ -20,9 +20,9 @@ SwerveSubsystem::SwerveSubsystem() : flModule(), frModule(), blModule(), brModul
     // Configure AutoBuilder
     AutoBuilder::configure(
         [this]() {return this->getPose();},
-        [this](frc::Pose2d pose) {this->resetPose(pose);},
+        [this](const frc::Pose2d& pose) {this->resetPose(pose);},
         [this]() {return this->getSpeeds();},
-        [this](frc::ChassisSpeeds robotRelativeSpeeds) {this->driveRobotRelative(robotRelativeSpeeds);},
+        [this](const frc::ChassisSpeeds& robotRelativeSpeeds) {this->driveRobotRelative(robotRelativeSpeeds);},
         std::make_shared<PPHolonomicDriveController>(
             SwerveConstants::translationConstants,
             SwerveConstants::rotationConstants
@@ -43,7 +43,7 @@ SwerveSubsystem::SwerveSubsystem() : flModule(), frModule(), blModule(), brModul
     );
 
     // Set up custom logging to add the current path to a field 2d widget
-    PathPlannerLogging::setLogActivePathCallback([this](auto poses) {
+    PathPlannerLogging::setLogActivePathCallback([this](const auto& poses) {
         this->field.GetObject("path")->SetPoses(poses);
     });
 

--- a/pathplannerlib/src/main/native/cpp/pathplanner/lib/auto/AutoBuilder.cpp
+++ b/pathplannerlib/src/main/native/cpp/pathplanner/lib/auto/AutoBuilder.cpp
@@ -16,7 +16,7 @@ using namespace pathplanner;
 bool AutoBuilder::m_configured = false;
 std::function<frc2::CommandPtr(std::shared_ptr<PathPlannerPath>)> AutoBuilder::m_pathFollowingCommandBuilder;
 std::function<frc::Pose2d()> AutoBuilder::m_poseSupplier;
-std::function<void(frc::Pose2d)> AutoBuilder::m_resetPose;
+std::function<void(const frc::Pose2d&)> AutoBuilder::m_resetPose;
 std::function<bool()> AutoBuilder::m_shouldFlipPath;
 bool AutoBuilder::m_isHolonomic = false;
 
@@ -32,9 +32,9 @@ std::function<
 		frc2::CommandPtr(std::shared_ptr<PathPlannerPath>, PathConstraints)> AutoBuilder::m_pathfindThenFollowPathCommandBuilder;
 
 void AutoBuilder::configure(std::function<frc::Pose2d()> poseSupplier,
-		std::function<void(frc::Pose2d)> resetPose,
+		std::function<void(const frc::Pose2d&)> resetPose,
 		std::function<frc::ChassisSpeeds()> robotRelativeSpeedsSupplier,
-		std::function<void(frc::ChassisSpeeds, DriveFeedforwards)> output,
+		std::function<void(const frc::ChassisSpeeds&, const DriveFeedforwards&)> output,
 		std::shared_ptr<PathFollowingController> controller,
 		RobotConfig robotConfig, std::function<bool()> shouldFlipPath,
 		frc2::Subsystem *driveSubsystem) {
@@ -79,7 +79,7 @@ void AutoBuilder::configure(std::function<frc::Pose2d()> poseSupplier,
 
 void AutoBuilder::configureCustom(std::function<frc::Pose2d()> poseSupplier,
 		std::function<frc2::CommandPtr(std::shared_ptr<PathPlannerPath>)> pathFollowingCommandBuilder,
-		std::function<void(frc::Pose2d)> resetPose, bool isHolonomic,
+		std::function<void(const frc::Pose2d&)> resetPose, bool isHolonomic,
 		std::function<bool()> shouldFlipPose) {
 	if (m_configured) {
 		FRC_ReportError(frc::err::Error,

--- a/pathplannerlib/src/main/native/cpp/pathplanner/lib/commands/FollowPathCommand.cpp
+++ b/pathplannerlib/src/main/native/cpp/pathplanner/lib/commands/FollowPathCommand.cpp
@@ -79,8 +79,8 @@ void FollowPathCommand::Initialize() {
 				currentPose.Rotation(), m_robotConfig);
 	}
 
-	PathPlannerLogging::logActivePath (m_path.get());
-	PPLibTelemetry::setCurrentPath(m_path);
+	PathPlannerLogging::logActivePath(m_path.get());
+	PPLibTelemetry::setCurrentPath (m_path);
 
 	m_eventScheduler.initialize(m_trajectory);
 

--- a/pathplannerlib/src/main/native/cpp/pathplanner/lib/commands/FollowPathCommand.cpp
+++ b/pathplannerlib/src/main/native/cpp/pathplanner/lib/commands/FollowPathCommand.cpp
@@ -8,7 +8,7 @@ using namespace pathplanner;
 FollowPathCommand::FollowPathCommand(std::shared_ptr<PathPlannerPath> path,
 		std::function<frc::Pose2d()> poseSupplier,
 		std::function<frc::ChassisSpeeds()> speedsSupplier,
-		std::function<void(frc::ChassisSpeeds, DriveFeedforwards)> output,
+		std::function<void(const frc::ChassisSpeeds&, const DriveFeedforwards&)> output,
 		std::shared_ptr<PathFollowingController> controller,
 		RobotConfig robotConfig, std::function<bool()> shouldFlipPath,
 		frc2::Requirements requirements) : m_originalPath(path), m_poseSupplier(
@@ -79,7 +79,7 @@ void FollowPathCommand::Initialize() {
 				currentPose.Rotation(), m_robotConfig);
 	}
 
-	PathPlannerLogging::logActivePath (m_path);
+	PathPlannerLogging::logActivePath (m_path.get());
 	PPLibTelemetry::setCurrentPath(m_path);
 
 	m_eventScheduler.initialize(m_trajectory);

--- a/pathplannerlib/src/main/native/cpp/pathplanner/lib/commands/PathfindingCommand.cpp
+++ b/pathplannerlib/src/main/native/cpp/pathplanner/lib/commands/PathfindingCommand.cpp
@@ -15,7 +15,7 @@ PathfindingCommand::PathfindingCommand(
 		std::shared_ptr<PathPlannerPath> targetPath,
 		PathConstraints constraints, std::function<frc::Pose2d()> poseSupplier,
 		std::function<frc::ChassisSpeeds()> speedsSupplier,
-		std::function<void(frc::ChassisSpeeds, DriveFeedforwards)> output,
+		std::function<void(const frc::ChassisSpeeds&, const DriveFeedforwards&)> output,
 		std::shared_ptr<PathFollowingController> controller,
 		RobotConfig robotConfig, std::function<bool()> shouldFlipPath,
 		frc2::Requirements requirements) : m_targetPath(targetPath), m_targetPose(), m_goalEndState(
@@ -59,7 +59,7 @@ PathfindingCommand::PathfindingCommand(frc::Pose2d targetPose,
 		PathConstraints constraints, units::meters_per_second_t goalEndVel,
 		std::function<frc::Pose2d()> poseSupplier,
 		std::function<frc::ChassisSpeeds()> speedsSupplier,
-		std::function<void(frc::ChassisSpeeds, DriveFeedforwards)> output,
+		std::function<void(const frc::ChassisSpeeds&, const DriveFeedforwards&)> output,
 		std::shared_ptr<PathFollowingController> controller,
 		RobotConfig robotConfig, frc2::Requirements requirements) : m_targetPath(), m_targetPose(
 		targetPose), m_originalTargetPose(targetPose), m_goalEndState(
@@ -168,7 +168,7 @@ void PathfindingCommand::Execute() {
 				m_timeOffset = 0.02_s;
 			}
 
-			PathPlannerLogging::logActivePath (m_currentPath);
+			PathPlannerLogging::logActivePath (m_currentPath.get());
 			PPLibTelemetry::setCurrentPath(m_currentPath);
 
 			m_timer.Reset();

--- a/pathplannerlib/src/main/native/cpp/pathplanner/lib/commands/PathfindingCommand.cpp
+++ b/pathplannerlib/src/main/native/cpp/pathplanner/lib/commands/PathfindingCommand.cpp
@@ -168,8 +168,8 @@ void PathfindingCommand::Execute() {
 				m_timeOffset = 0.02_s;
 			}
 
-			PathPlannerLogging::logActivePath (m_currentPath.get());
-			PPLibTelemetry::setCurrentPath(m_currentPath);
+			PathPlannerLogging::logActivePath(m_currentPath.get());
+			PPLibTelemetry::setCurrentPath (m_currentPath);
 
 			m_timer.Reset();
 			m_timer.Start();

--- a/pathplannerlib/src/main/native/cpp/pathplanner/lib/util/PathPlannerLogging.cpp
+++ b/pathplannerlib/src/main/native/cpp/pathplanner/lib/util/PathPlannerLogging.cpp
@@ -2,6 +2,6 @@
 
 using namespace pathplanner;
 
-std::function<void(frc::Pose2d)> PathPlannerLogging::m_logCurrentPose;
-std::function<void(frc::Pose2d)> PathPlannerLogging::m_logTargetPose;
-std::function<void(std::vector<frc::Pose2d>&)> PathPlannerLogging::m_logActivePath;
+std::function<void(const frc::Pose2d&)> PathPlannerLogging::m_logCurrentPose;
+std::function<void(const frc::Pose2d&)> PathPlannerLogging::m_logTargetPose;
+std::function<void(const std::vector<frc::Pose2d>&)> PathPlannerLogging::m_logActivePath;

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/auto/AutoBuilder.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/auto/AutoBuilder.h
@@ -44,9 +44,9 @@ public:
 	 * @param driveSubsystem a pointer to the subsystem for the robot's drive
 	 */
 	static void configure(std::function<frc::Pose2d()> poseSupplier,
-			std::function<void(frc::Pose2d)> resetPose,
+			std::function<void(const frc::Pose2d&)> resetPose,
 			std::function<frc::ChassisSpeeds()> robotRelativeSpeedsSupplier,
-			std::function<void(frc::ChassisSpeeds, DriveFeedforwards)> output,
+			std::function<void(const frc::ChassisSpeeds&, const DriveFeedforwards&)> output,
 			std::shared_ptr<PathFollowingController> controller,
 			RobotConfig robotConfig, std::function<bool()> shouldFlipPath,
 			frc2::Subsystem *driveSubsystem);
@@ -65,16 +65,16 @@ public:
 	 * @param driveSubsystem a pointer to the subsystem for the robot's drive
 	 */
 	static inline void configure(std::function<frc::Pose2d()> poseSupplier,
-			std::function<void(frc::Pose2d)> resetPose,
+			std::function<void(const frc::Pose2d&)> resetPose,
 			std::function<frc::ChassisSpeeds()> robotRelativeSpeedsSupplier,
-			std::function<void(frc::ChassisSpeeds)> output,
+			std::function<void(const frc::ChassisSpeeds&)> output,
 			std::shared_ptr<PathFollowingController> controller,
 			RobotConfig robotConfig, std::function<bool()> shouldFlipPath,
 			frc2::Subsystem *driveSubsystem) {
 		configure(poseSupplier, resetPose, robotRelativeSpeedsSupplier,
-				[output](auto speeds, auto feedforwards) {
+				[output](auto &&speeds, auto &&feedforwards) {
 					output(speeds);
-				}, controller, robotConfig, shouldFlipPath, driveSubsystem);
+				}, std::move(controller), std::move(robotConfig), shouldFlipPath, driveSubsystem);
 	}
 
 	/**
@@ -93,7 +93,7 @@ public:
 	 */
 	static void configureCustom(std::function<frc::Pose2d()> poseSupplier,
 			std::function<frc2::CommandPtr(std::shared_ptr<PathPlannerPath>)> pathFollowingCommandBuilder,
-			std::function<void(frc::Pose2d)> resetPose, bool isHolonomic,
+			std::function<void(const frc::Pose2d&)> resetPose, bool isHolonomic,
 			std::function<bool()> shouldFlipPose = []() {
 				return false;
 			});
@@ -277,7 +277,7 @@ private:
 	static bool m_configured;
 	static std::function<frc2::CommandPtr(std::shared_ptr<PathPlannerPath>)> m_pathFollowingCommandBuilder;
 	static std::function<frc::Pose2d()> m_poseSupplier;
-	static std::function<void(frc::Pose2d)> m_resetPose;
+	static std::function<void(const frc::Pose2d&)> m_resetPose;
 	static std::function<bool()> m_shouldFlipPath;
 	static bool m_isHolonomic;
 

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/auto/AutoBuilder.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/auto/AutoBuilder.h
@@ -46,7 +46,8 @@ public:
 	static void configure(std::function<frc::Pose2d()> poseSupplier,
 			std::function<void(const frc::Pose2d&)> resetPose,
 			std::function<frc::ChassisSpeeds()> robotRelativeSpeedsSupplier,
-			std::function<void(const frc::ChassisSpeeds&, const DriveFeedforwards&)> output,
+			std::function<
+					void(const frc::ChassisSpeeds&, const DriveFeedforwards&)> output,
 			std::shared_ptr<PathFollowingController> controller,
 			RobotConfig robotConfig, std::function<bool()> shouldFlipPath,
 			frc2::Subsystem *driveSubsystem);
@@ -74,7 +75,8 @@ public:
 		configure(poseSupplier, resetPose, robotRelativeSpeedsSupplier,
 				[output](auto &&speeds, auto &&feedforwards) {
 					output(speeds);
-				}, std::move(controller), std::move(robotConfig), shouldFlipPath, driveSubsystem);
+				}, std::move(controller), std::move(robotConfig),
+				shouldFlipPath, driveSubsystem);
 	}
 
 	/**

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/commands/FollowPathCommand.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/commands/FollowPathCommand.h
@@ -45,7 +45,7 @@ public:
 	FollowPathCommand(std::shared_ptr<PathPlannerPath> path,
 			std::function<frc::Pose2d()> poseSupplier,
 			std::function<frc::ChassisSpeeds()> speedsSupplier,
-			std::function<void(frc::ChassisSpeeds, DriveFeedforwards)> output,
+			std::function<void(const frc::ChassisSpeeds&, const DriveFeedforwards&)> output,
 			std::shared_ptr<PathFollowingController> controller,
 			RobotConfig robotConfig, std::function<bool()> shouldFlipPath,
 			frc2::Requirements requirements);
@@ -63,7 +63,7 @@ private:
 	std::shared_ptr<PathPlannerPath> m_originalPath;
 	std::function<frc::Pose2d()> m_poseSupplier;
 	std::function<frc::ChassisSpeeds()> m_speedsSupplier;
-	std::function<void(frc::ChassisSpeeds, DriveFeedforwards)> m_output;
+	std::function<void(const frc::ChassisSpeeds&, const DriveFeedforwards&)> m_output;
 	std::shared_ptr<PathFollowingController> m_controller;
 	RobotConfig m_robotConfig;
 	std::function<bool()> m_shouldFlipPath;

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/commands/FollowPathCommand.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/commands/FollowPathCommand.h
@@ -45,7 +45,8 @@ public:
 	FollowPathCommand(std::shared_ptr<PathPlannerPath> path,
 			std::function<frc::Pose2d()> poseSupplier,
 			std::function<frc::ChassisSpeeds()> speedsSupplier,
-			std::function<void(const frc::ChassisSpeeds&, const DriveFeedforwards&)> output,
+			std::function<
+					void(const frc::ChassisSpeeds&, const DriveFeedforwards&)> output,
 			std::shared_ptr<PathFollowingController> controller,
 			RobotConfig robotConfig, std::function<bool()> shouldFlipPath,
 			frc2::Requirements requirements);

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/commands/PathfindThenFollowPath.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/commands/PathfindThenFollowPath.h
@@ -29,7 +29,8 @@ public:
 			PathConstraints pathfindingConstraints,
 			std::function<frc::Pose2d()> poseSupplier,
 			std::function<frc::ChassisSpeeds()> currentRobotRelativeSpeeds,
-			std::function<void(const frc::ChassisSpeeds&, const DriveFeedforwards&)> output,
+			std::function<
+					void(const frc::ChassisSpeeds&, const DriveFeedforwards&)> output,
 			std::shared_ptr<PathFollowingController> controller,
 			RobotConfig robotConfig, std::function<bool()> shouldFlipPath,
 			frc2::Requirements requirements) {

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/commands/PathfindThenFollowPath.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/commands/PathfindThenFollowPath.h
@@ -29,7 +29,7 @@ public:
 			PathConstraints pathfindingConstraints,
 			std::function<frc::Pose2d()> poseSupplier,
 			std::function<frc::ChassisSpeeds()> currentRobotRelativeSpeeds,
-			std::function<void(frc::ChassisSpeeds, DriveFeedforwards)> output,
+			std::function<void(const frc::ChassisSpeeds&, const DriveFeedforwards&)> output,
 			std::shared_ptr<PathFollowingController> controller,
 			RobotConfig robotConfig, std::function<bool()> shouldFlipPath,
 			frc2::Requirements requirements) {

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/commands/PathfindingCommand.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/commands/PathfindingCommand.h
@@ -45,7 +45,8 @@ public:
 			PathConstraints constraints,
 			std::function<frc::Pose2d()> poseSupplier,
 			std::function<frc::ChassisSpeeds()> speedsSupplier,
-			std::function<void(const frc::ChassisSpeeds&, const DriveFeedforwards&)> output,
+			std::function<
+					void(const frc::ChassisSpeeds&, const DriveFeedforwards&)> output,
 			std::shared_ptr<PathFollowingController> controller,
 			RobotConfig robotConfig, std::function<bool()> shouldFlipPath,
 			frc2::Requirements requirements);
@@ -72,7 +73,8 @@ public:
 			units::meters_per_second_t goalEndVel,
 			std::function<frc::Pose2d()> poseSupplier,
 			std::function<frc::ChassisSpeeds()> speedsSupplier,
-			std::function<void(const frc::ChassisSpeeds&, const DriveFeedforwards&)> output,
+			std::function<
+					void(const frc::ChassisSpeeds&, const DriveFeedforwards&)> output,
 			std::shared_ptr<PathFollowingController> controller,
 			RobotConfig robotConfig, frc2::Requirements requirements);
 

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/commands/PathfindingCommand.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/commands/PathfindingCommand.h
@@ -45,7 +45,7 @@ public:
 			PathConstraints constraints,
 			std::function<frc::Pose2d()> poseSupplier,
 			std::function<frc::ChassisSpeeds()> speedsSupplier,
-			std::function<void(frc::ChassisSpeeds, DriveFeedforwards)> output,
+			std::function<void(const frc::ChassisSpeeds&, const DriveFeedforwards&)> output,
 			std::shared_ptr<PathFollowingController> controller,
 			RobotConfig robotConfig, std::function<bool()> shouldFlipPath,
 			frc2::Requirements requirements);
@@ -72,7 +72,7 @@ public:
 			units::meters_per_second_t goalEndVel,
 			std::function<frc::Pose2d()> poseSupplier,
 			std::function<frc::ChassisSpeeds()> speedsSupplier,
-			std::function<void(frc::ChassisSpeeds, DriveFeedforwards)> output,
+			std::function<void(const frc::ChassisSpeeds&, const DriveFeedforwards&)> output,
 			std::shared_ptr<PathFollowingController> controller,
 			RobotConfig robotConfig, frc2::Requirements requirements);
 
@@ -93,7 +93,7 @@ private:
 	PathConstraints m_constraints;
 	std::function<frc::Pose2d()> m_poseSupplier;
 	std::function<frc::ChassisSpeeds()> m_speedsSupplier;
-	std::function<void(frc::ChassisSpeeds, DriveFeedforwards)> m_output;
+	std::function<void(const frc::ChassisSpeeds&, const DriveFeedforwards&)> m_output;
 	std::shared_ptr<PathFollowingController> m_controller;
 	RobotConfig m_robotConfig;
 	std::function<bool()> m_shouldFlipPath;

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/path/PathPlannerPath.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/path/PathPlannerPath.h
@@ -314,7 +314,7 @@ public:
 	 *
 	 * @return List of poses for each point in this path
 	 */
-	inline std::vector<frc::Pose2d> getPathPoses() {
+	inline std::vector<frc::Pose2d> getPathPoses() const {
 		std::vector < frc::Pose2d > poses;
 		for (const PathPoint &point : m_allPoints) {
 			poses.emplace_back(point.position, frc::Rotation2d());

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/util/PathPlannerLogging.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/util/PathPlannerLogging.h
@@ -11,33 +11,33 @@ namespace pathplanner {
 class PathPlannerLogging {
 public:
 	static inline void setLogCurrentPoseCallback(
-			std::function<void(frc::Pose2d)> logCurrentPose) {
+			std::function<void(const frc::Pose2d&)> logCurrentPose) {
 		m_logCurrentPose = logCurrentPose;
 	}
 
 	static inline void setLogTargetPoseCallback(
-			std::function<void(frc::Pose2d)> logTargetPose) {
+			std::function<void(const frc::Pose2d&)> logTargetPose) {
 		m_logTargetPose = logTargetPose;
 	}
 
 	static inline void setLogActivePathCallback(
-			std::function<void(std::vector<frc::Pose2d>)> logActivePath) {
+			std::function<void(const std::vector<frc::Pose2d>&)> logActivePath) {
 		m_logActivePath = logActivePath;
 	}
 
-	static inline void logCurrentPose(frc::Pose2d pose) {
+	static inline void logCurrentPose(const frc::Pose2d& pose) {
 		if (m_logCurrentPose) {
 			m_logCurrentPose(pose);
 		}
 	}
 
-	static inline void logTargetPose(frc::Pose2d targetPose) {
+	static inline void logTargetPose(const frc::Pose2d& targetPose) {
 		if (m_logTargetPose) {
 			m_logTargetPose(targetPose);
 		}
 	}
 
-	static void logActivePath(std::shared_ptr<PathPlannerPath> path) {
+	static void logActivePath(const PathPlannerPath* path) {
 		if (m_logActivePath) {
 			std::vector < frc::Pose2d > poses;
 
@@ -50,8 +50,8 @@ public:
 	}
 
 private:
-	static std::function<void(frc::Pose2d)> m_logCurrentPose;
-	static std::function<void(frc::Pose2d)> m_logTargetPose;
-	static std::function<void(std::vector<frc::Pose2d>&)> m_logActivePath;
+	static std::function<void(const frc::Pose2d&)> m_logCurrentPose;
+	static std::function<void(const frc::Pose2d&)> m_logTargetPose;
+	static std::function<void(const std::vector<frc::Pose2d>&)> m_logActivePath;
 };
 }

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/util/PathPlannerLogging.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/util/PathPlannerLogging.h
@@ -25,19 +25,19 @@ public:
 		m_logActivePath = logActivePath;
 	}
 
-	static inline void logCurrentPose(const frc::Pose2d& pose) {
+	static inline void logCurrentPose(const frc::Pose2d &pose) {
 		if (m_logCurrentPose) {
 			m_logCurrentPose(pose);
 		}
 	}
 
-	static inline void logTargetPose(const frc::Pose2d& targetPose) {
+	static inline void logTargetPose(const frc::Pose2d &targetPose) {
 		if (m_logTargetPose) {
 			m_logTargetPose(targetPose);
 		}
 	}
 
-	static void logActivePath(const PathPlannerPath* path) {
+	static void logActivePath(const PathPlannerPath *path) {
 		if (m_logActivePath) {
 			std::vector < frc::Pose2d > poses;
 


### PR DESCRIPTION
The C++ `AutoBuilder` lambdas can take const references instead of values. WPILib typically passes `Pose2d` and `ChassisSpeeds` by const reference, and the `DriveFeedforwards` type contains vectors that shouldn't be copied on every call to `output`.