### PR TITLE
Angle check

### DIFF
--- a/pathplannerlib-python/pathplannerlib/trajectory.py
+++ b/pathplannerlib-python/pathplannerlib/trajectory.py
@@ -233,8 +233,9 @@ class PathPlannerTrajectory:
                     forceXFF = []
                     forceYFF = []
                     for m in range(config.numModules):
-                        appliedForce = wheelForces[m].norm() * (
-                                wheelForces[m].angle() - state.moduleStates[m].angle).cos()
+                        wheelForceDist = wheelForces[m].norm()
+                        appliedForce = 0.0 if wheelForceDist <= 1e-6 else wheelForceDist * (
+                            wheelForces[m].angle() - state.moduleStates[m].angle).cos()
                         wheelTorque = appliedForce * config.moduleConfig.wheelRadiusMeters
                         torqueCurrent = wheelTorque / config.moduleConfig.driveMotor.Kt
 

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/trajectory/PathPlannerTrajectory.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/trajectory/PathPlannerTrajectory.java
@@ -159,9 +159,10 @@ public class PathPlannerTrajectory {
         double[] forceXFF = new double[config.numModules];
         double[] forceYFF = new double[config.numModules];
         for (int m = 0; m < config.numModules; m++) {
+          double wheelForceDist = wheelForces[m].getNorm();
           double appliedForce =
-              wheelForces[m].getNorm() > 1e-6
-                  ? wheelForces[m].getNorm()
+              wheelForceDist > 1e-6
+                  ? wheelForceDist
                       * wheelForces[m].getAngle().minus(state.moduleStates[m].angle).getCos()
                   : 0.0;
           double wheelTorque = appliedForce * config.moduleConfig.wheelRadiusMeters;

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/trajectory/PathPlannerTrajectory.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/trajectory/PathPlannerTrajectory.java
@@ -159,9 +159,11 @@ public class PathPlannerTrajectory {
         double[] forceXFF = new double[config.numModules];
         double[] forceYFF = new double[config.numModules];
         for (int m = 0; m < config.numModules; m++) {
-          double appliedForce =
-              wheelForces[m].getNorm()
-                  * wheelForces[m].getAngle().minus(state.moduleStates[m].angle).getCos();
+          double appliedForce = 
+              wheelForces[m].getNorm() > 1e-6
+              ? wheelForces[m].getNorm() 
+                      * wheelForces[m].getAngle().minus(state.moduleStates[m].angle).getCos() 
+              : 0.0;
           double wheelTorque = appliedForce * config.moduleConfig.wheelRadiusMeters;
           double torqueCurrent = config.moduleConfig.driveMotor.getCurrent(wheelTorque);
 

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/trajectory/PathPlannerTrajectory.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/trajectory/PathPlannerTrajectory.java
@@ -159,11 +159,11 @@ public class PathPlannerTrajectory {
         double[] forceXFF = new double[config.numModules];
         double[] forceYFF = new double[config.numModules];
         for (int m = 0; m < config.numModules; m++) {
-          double appliedForce = 
+          double appliedForce =
               wheelForces[m].getNorm() > 1e-6
-              ? wheelForces[m].getNorm() 
-                      * wheelForces[m].getAngle().minus(state.moduleStates[m].angle).getCos() 
-              : 0.0;
+                  ? wheelForces[m].getNorm()
+                      * wheelForces[m].getAngle().minus(state.moduleStates[m].angle).getCos()
+                  : 0.0;
           double wheelTorque = appliedForce * config.moduleConfig.wheelRadiusMeters;
           double torqueCurrent = config.moduleConfig.driveMotor.getCurrent(wheelTorque);
 

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/util/swerve/SwerveSetpointGenerator.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/util/swerve/SwerveSetpointGenerator.java
@@ -342,7 +342,9 @@ public class SwerveSetpointGenerator {
     double[] forceYFF = new double[config.numModules];
     for (int m = 0; m < config.numModules; m++) {
       double appliedForce =
-          wheelForces[m].getNorm() * wheelForces[m].getAngle().minus(retStates[m].angle).getCos();
+        wheelForces[m].getNorm() > 1e-6
+            ? wheelForces[m].getNorm() * wheelForces[m].getAngle().minus(retStates[m].angle).getCos()
+            : 0.0;
       double wheelTorque = appliedForce * config.moduleConfig.wheelRadiusMeters;
       double torqueCurrent = config.moduleConfig.driveMotor.getCurrent(wheelTorque);
 

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/util/swerve/SwerveSetpointGenerator.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/util/swerve/SwerveSetpointGenerator.java
@@ -341,10 +341,10 @@ public class SwerveSetpointGenerator {
     double[] forceXFF = new double[config.numModules];
     double[] forceYFF = new double[config.numModules];
     for (int m = 0; m < config.numModules; m++) {
+      double wheelForceDist = wheelForces[m].getNorm();
       double appliedForce =
-          wheelForces[m].getNorm() > 1e-6
-              ? wheelForces[m].getNorm()
-                  * wheelForces[m].getAngle().minus(retStates[m].angle).getCos()
+          wheelForceDist > 1e-6
+              ? wheelForceDist * wheelForces[m].getAngle().minus(retStates[m].angle).getCos()
               : 0.0;
       double wheelTorque = appliedForce * config.moduleConfig.wheelRadiusMeters;
       double torqueCurrent = config.moduleConfig.driveMotor.getCurrent(wheelTorque);

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/util/swerve/SwerveSetpointGenerator.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/util/swerve/SwerveSetpointGenerator.java
@@ -342,9 +342,10 @@ public class SwerveSetpointGenerator {
     double[] forceYFF = new double[config.numModules];
     for (int m = 0; m < config.numModules; m++) {
       double appliedForce =
-        wheelForces[m].getNorm() > 1e-6
-            ? wheelForces[m].getNorm() * wheelForces[m].getAngle().minus(retStates[m].angle).getCos()
-            : 0.0;
+          wheelForces[m].getNorm() > 1e-6
+              ? wheelForces[m].getNorm()
+                  * wheelForces[m].getAngle().minus(retStates[m].angle).getCos()
+              : 0.0;
       double wheelTorque = appliedForce * config.moduleConfig.wheelRadiusMeters;
       double torqueCurrent = config.moduleConfig.driveMotor.getCurrent(wheelTorque);
 

--- a/pathplannerlib/src/main/native/cpp/pathplanner/lib/trajectory/PathPlannerTrajectory.cpp
+++ b/pathplannerlib/src/main/native/cpp/pathplanner/lib/trajectory/PathPlannerTrajectory.cpp
@@ -140,10 +140,13 @@ PathPlannerTrajectory::PathPlannerTrajectory(
 			std::vector < units::newton_t > forceXFF;
 			std::vector < units::newton_t > forceYFF;
 			for (size_t m = 0; m < config.numModules; m++) {
-				units::newton_t appliedForce {
-						wheelForces[m].Norm()()
-								* (wheelForces[m].Angle()
-										- state.moduleStates[m].angle).Cos() };
+				units::meter_t wheelForceDist = wheelForces[m].Norm();
+				units::newton_t appliedForce { 0.0 };
+				if (wheelForceDist() > 1e-6) {
+					appliedForce = units::newton_t { wheelForceDist()
+							* (wheelForces[m].Angle()
+									- state.moduleStates[m].angle).Cos() };
+				}
 				units::newton_meter_t wheelTorque = appliedForce
 						* config.moduleConfig.wheelRadius;
 				units::ampere_t torqueCurrent =


### PR DESCRIPTION
Add an angle check to prevent the following from being printed continuously (may need to be added on some other `getAngle()` as well. 

```
Error at java.base/java.lang.Thread.getStackTrace(Thread.java:1619): x and y components of Rotation2d are zero

        at java.base/java.lang.Thread.getStackTrace(Thread.java:1619)
        at edu.wpi.first.math.geometry.Rotation2d.<init>(Rotation2d.java:122)
        at edu.wpi.first.math.geometry.Translation2d.getAngle(Translation2d.java:174)
        at com.pathplanner.lib.util.swerve.SwerveSetpointGenerator.generateSetpoint(SwerveSetpointGenerator.java:345)
       ....
        at com.ctre.phoenix6.swerve.SwerveDrivetrain.setControl(SwerveDrivetrain.java:413)
        at frc.robot.subsystems.drivetrain.CommandSwerveDrivetrain.lambda$14(CommandSwerveDrivetrain.java:266)
        at edu.wpi.first.wpilibj2.command.FunctionalCommand.execute(FunctionalCommand.java:57)
        at edu.wpi.first.wpilibj2.command.CommandScheduler.run(CommandScheduler.java:288)
        at frc.robot.Robot.robotPeriodic(Robot.java:27)
        at edu.wpi.first.wpilibj.IterativeRobotBase.loopFunc(IterativeRobotBase.java:400)
        at edu.wpi.first.wpilibj.TimedRobot.startCompetition(TimedRobot.java:131)
tRobot$0(RobotBase.java:418)
        at java.base/java.lang.Thread.run(Thread.java:840)
```