### PR TITLE
Fix `FlippingUtil` behavior with `kMirrored` robot-relative forces and `kRotational` field rotation

### DIFF
--- a/pathplannerlib-python/pathplannerlib/util.py
+++ b/pathplannerlib-python/pathplannerlib/util.py
@@ -77,8 +77,8 @@ class DriveFeedforwards:
             FlippingUtil.flipFeedforwards(self.accelerationsMPS),
             FlippingUtil.flipFeedforwards(self.forcesNewtons),
             FlippingUtil.flipFeedforwards(self.torqueCurrentsAmps),
-            FlippingUtil.flipFeedforwards(self.robotRelativeForcesXNewtons),
-            FlippingUtil.flipFeedforwards(self.robotRelativeForcesYNewtons)
+            FlippingUtil.flipFeedforwardXs(self.robotRelativeForcesXNewtons),
+            FlippingUtil.flipFeedforwardYs(self.robotRelativeForcesYNewtons)
         )
 
     @staticmethod
@@ -112,7 +112,10 @@ class FlippingUtil:
         :param rotation: The rotation to flip
         :return: The flipped rotation
         """
-        return Rotation2d(math.pi) - rotation
+        if FlippingUtil.symmetryType == FieldSymmetry.kMirrored:
+            return Rotation2d(math.pi) - rotation
+        else:
+            return rotation - Rotation2d(math.pi)
 
     @staticmethod
     def flipFieldPose(pose: Pose2d) -> Pose2d:
@@ -153,6 +156,31 @@ class FlippingUtil:
             elif len(feedforwards) == 2:
                 return [feedforwards[1], feedforwards[0]]
         return feedforwards
+
+    @classmethod
+    def flipFeedforwardXs(clazz, feedforwardXs: List[float]) -> List[float]:
+        """
+        Flip a list of drive feedforward X components for the other side of
+        the field. Only does anything if mirrored symmetry is used
+
+        :param feedforwardXs: List of drive feedforward X components
+        :return: The flipped feedforward X components
+        """
+        return clazz.flipFeedforwards(feedforwardXs)
+
+    @classmethod
+    def flipFeedforwardYs(clazz, feedforwardYs: List[float]) -> List[float]:
+        """
+        Flip a list of drive feedforward Y components for the other side of
+        the field. Only does anything if mirrored symmetry is used
+
+        :param feedforwardYs: List of drive feedforward Y components
+        :return: The flipped feedforward Y components
+        """
+        flippedFeedforwardYs = clazz.flipFeedforwards(feedforwardYs)
+        if FlippingUtil.symmetryType == FieldSymmetry.kMirrored:
+            return [-feedforward for feedforward in flippedFeedforwardYs]
+        return flippedFeedforwardYs
 
 
 def floatLerp(start_val: float, end_val: float, t: float) -> float:

--- a/pathplannerlib-python/pathplannerlib/util.py
+++ b/pathplannerlib-python/pathplannerlib/util.py
@@ -157,8 +157,8 @@ class FlippingUtil:
                 return [feedforwards[1], feedforwards[0]]
         return feedforwards
 
-    @classmethod
-    def flipFeedforwardXs(clazz, feedforwardXs: List[float]) -> List[float]:
+    @staticmethod
+    def flipFeedforwardXs(feedforwardXs: List[float]) -> List[float]:
         """
         Flip a list of drive feedforward X components for the other side of
         the field. Only does anything if mirrored symmetry is used
@@ -166,10 +166,10 @@ class FlippingUtil:
         :param feedforwardXs: List of drive feedforward X components
         :return: The flipped feedforward X components
         """
-        return clazz.flipFeedforwards(feedforwardXs)
+        return FlippingUtil.flipFeedforwards(feedforwardXs)
 
-    @classmethod
-    def flipFeedforwardYs(clazz, feedforwardYs: List[float]) -> List[float]:
+    @staticmethod
+    def flipFeedforwardYs(feedforwardYs: List[float]) -> List[float]:
         """
         Flip a list of drive feedforward Y components for the other side of
         the field. Only does anything if mirrored symmetry is used
@@ -177,7 +177,7 @@ class FlippingUtil:
         :param feedforwardYs: List of drive feedforward Y components
         :return: The flipped feedforward Y components
         """
-        flippedFeedforwardYs = clazz.flipFeedforwards(feedforwardYs)
+        flippedFeedforwardYs = FlippingUtil.flipFeedforwards(feedforwardYs)
         if FlippingUtil.symmetryType == FieldSymmetry.kMirrored:
             return [-feedforward for feedforward in flippedFeedforwardYs]
         return flippedFeedforwardYs

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/util/DriveFeedforwards.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/util/DriveFeedforwards.java
@@ -115,8 +115,8 @@ public record DriveFeedforwards(
         FlippingUtil.flipFeedforwards(accelerationsMPSSq),
         FlippingUtil.flipFeedforwards(linearForcesNewtons),
         FlippingUtil.flipFeedforwards(torqueCurrentsAmps),
-        FlippingUtil.flipFeedforwards(robotRelativeForcesXNewtons),
-        FlippingUtil.flipFeedforwards(robotRelativeForcesYNewtons));
+        FlippingUtil.flipFeedforwardXs(robotRelativeForcesXNewtons),
+        FlippingUtil.flipFeedforwardYs(robotRelativeForcesYNewtons));
   }
 
   /**

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/util/FlippingUtil.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/util/FlippingUtil.java
@@ -102,4 +102,36 @@ public class FlippingUtil {
       case kRotational -> feedforwards;
     };
   }
+
+  /**
+   * Flip an array of drive feedforward X components for the other side of the field. Only does
+   * anything if mirrored symmetry is used
+   *
+   * @param feedforwardXs Array of drive feedforward X components
+   * @return The flipped feedforward X components
+   */
+  public static double[] flipFeedforwardXs(double[] feedforwardXs) {
+    return flipFeedforwards(feedforwardXs);
+  }
+
+  /**
+   * Flip an array of drive feedforward Y components for the other side of the field. Only does
+   * anything if mirrored symmetry is used
+   *
+   * @param feedforwardYs Array of drive feedforward Y components
+   * @return The flipped feedforward Y components
+   */
+  public static double[] flipFeedforwardYs(double[] feedforwardYs) {
+    var flippedFeedforwardYs = flipFeedforwards(feedforwardYs);
+    return switch (symmetryType) {
+      case kMirrored -> {
+        // Y directions also need to be inverted
+        for (int i = 0; i < flippedFeedforwardYs.length; ++i) {
+          flippedFeedforwardYs[i] *= -1;
+        }
+        yield flippedFeedforwardYs;
+      }
+      case kRotational -> flippedFeedforwardYs;
+    };
+  }
 }

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/util/FlippingUtil.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/util/FlippingUtil.java
@@ -46,7 +46,8 @@ public class FlippingUtil {
    */
   public static Rotation2d flipFieldRotation(Rotation2d rotation) {
     return switch (symmetryType) {
-      case kMirrored, kRotational -> new Rotation2d(Math.PI).minus(rotation);
+      case kMirrored -> new Rotation2d(Math.PI).minus(rotation);
+      case kRotational -> rotation.minus(new Rotation2d(Math.PI));
     };
   }
 

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/util/DriveFeedforwards.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/util/DriveFeedforwards.h
@@ -76,8 +76,8 @@ public:
 		return DriveFeedforwards { FlippingUtil::flipFeedforwards(
 				accelerations), FlippingUtil::flipFeedforwards(linearForces),
 				FlippingUtil::flipFeedforwards(torqueCurrents),
-				FlippingUtil::flipFeedforwards(robotRelativeForcesX),
-				FlippingUtil::flipFeedforwards(robotRelativeForcesY) };
+				FlippingUtil::flipFeedforwardXs(robotRelativeForcesX),
+				FlippingUtil::flipFeedforwardYs(robotRelativeForcesY) };
 	}
 
 private:

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/util/FlippingUtil.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/util/FlippingUtil.h
@@ -83,6 +83,13 @@ public:
 		}
 	}
 
+	/**
+	 * Flip an array of drive feedforwards for the other side of the field. Only does anything if
+	 * mirrored symmetry is used
+	 *
+	 * @param feedforwards Array of drive feedforwards
+	 * @return The flipped feedforwards
+	 */
 	template<class UnitType, class = std::enable_if_t<
 			units::traits::is_unit_t<UnitType>::value>>
 	static inline std::vector<UnitType> flipFeedforwards(
@@ -99,6 +106,45 @@ public:
 				return std::vector<UnitType> { feedforwards[1], feedforwards[0] };
 			}
 			return feedforwards; // idk
+		}
+	}
+
+	/**
+	 * Flip an array of drive feedforward X components for the other side of the field. Only does
+	 * anything if mirrored symmetry is used
+	 *
+	 * @param feedforwardXs Array of drive feedforward X components
+	 * @return The flipped feedforward X components
+	 */
+	template<class UnitType, class = std::enable_if_t<
+			units::traits::is_unit_t<UnitType>::value>>
+	static inline std::vector<UnitType> flipFeedforwardXs(
+			const std::vector<UnitType> &feedforwardXs) {
+		return flipFeedforwards(feedforwardXs);
+	}
+
+	/**
+	 * Flip an array of drive feedforward Y components for the other side of the field. Only does
+	 * anything if mirrored symmetry is used
+	 *
+	 * @param feedforwardYs Array of drive feedforward Y components
+	 * @return The flipped feedforward Y components
+	 */
+	template<class UnitType, class = std::enable_if_t<
+			units::traits::is_unit_t<UnitType>::value>>
+	static inline std::vector<UnitType> flipFeedforwardYs(
+			const std::vector<UnitType> &feedforwardYs) {
+		auto flippedFeedforwardYs = flipFeedforwards(feedforwardYs);
+		switch (symmetryType) {
+		case kRotational:
+			return flippedFeedforwardYs;
+		case kMirrored:
+		default:
+			// Y directions also need to be inverted
+			for (auto &feedforwardY : flippedFeedforwardYs) {
+				feedforwardY *= -1;
+			}
+			return flippedFeedforwardYs;
 		}
 	}
 };

--- a/pathplannerlib/src/main/native/include/pathplanner/lib/util/FlippingUtil.h
+++ b/pathplannerlib/src/main/native/include/pathplanner/lib/util/FlippingUtil.h
@@ -44,8 +44,9 @@ public:
 	static inline frc::Rotation2d flipFieldRotation(
 			const frc::Rotation2d &rotation) {
 		switch (symmetryType) {
-		case kMirrored:
 		case kRotational:
+			return rotation - frc::Rotation2d(180_deg);
+		case kMirrored:
 		default:
 			return frc::Rotation2d(180_deg) - rotation;
 		}


### PR DESCRIPTION
1. The robot-relative feedforward Y components need to be inverted in `kMirrored` mode, as left and right are flipped.
2. In `kRotational` mode, the field rotation needs to be rotated by 180 degrees, not subtracted from 180 degrees. For example, a 90 degree rotation should become -90 after rotating, but stay 90 degrees after mirroring.

I wasn't sure what the best way to implement 1 is API-wise, so for now I implemented two new functions `flipFeedforwardXs` and `flipFeedforwardYs` to handle the two components. Feel free to rename the functions or try to merge them into the existing `flipFeedforwards` function