### PR TITLE
Add Empty Translation check for forceVec

### DIFF
--- a/pathplannerlib-python/pathplannerlib/trajectory.py
+++ b/pathplannerlib-python/pathplannerlib/trajectory.py
@@ -497,7 +497,10 @@ def _forwardAccelPass(states: List[PathPlannerTrajectoryState], config: RobotCon
 
             # Calculate the torque this module will apply to the robot
             angleToModule = (state.moduleStates[m].fieldPos - state.pose.translation()).angle()
-            theta = forceVec.angle() - angleToModule
+            if forceVec == Translation2d():
+                theta = Rotation2d() - angleToModule
+            else:
+                theta = forceVec.angle() - angleToModule
             totalTorque += forceAtCarpet * config.modulePivotDistance[m] * theta.sin()
 
         # Use the robot accelerations to calculate how each module should accelerate


### PR DESCRIPTION
On robot initialization, the console output would have the following warning occasionally:

```Error at `anonymous-namespace'::WPILibMathShared::ReportErrorV: Error: x and y components of Rotation2d are zero```

After some print debugging, I found this was caused by forceVec being an empty Translation2d. This simply adds a check for the forceVec Translation2d to avoid sending warnings to the console.

I'm unaware if this issue is present in other languages.