### PR TITLE
[Swerve Setpoint Generator] Prevent force from being applied to chassisTorque if the magnitude of the force is 0

### DIFF
--- a/pathplannerlib/src/main/java/com/pathplanner/lib/util/swerve/SwerveSetpointGenerator.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/util/swerve/SwerveSetpointGenerator.java
@@ -273,9 +273,11 @@ public class SwerveSetpointGenerator {
       chassisForceVec = chassisForceVec.plus(moduleForceVec);
 
       // Calculate the torque this module will apply to the chassis
-      Rotation2d angleToModule = config.moduleLocations[m].getAngle();
-      Rotation2d theta = moduleForceVec.getAngle().minus(angleToModule);
-      chassisTorque += forceAtCarpet * config.modulePivotDistance[m] * theta.getSin();
+      if (!epsilonEquals(0, moduleForceVec.getNorm())) {
+        Rotation2d angleToModule = config.moduleLocations[m].getAngle();
+        Rotation2d theta = moduleForceVec.getAngle().minus(angleToModule);
+        chassisTorque += forceAtCarpet * config.modulePivotDistance[m] * theta.getSin();
+      }
     }
 
     Translation2d chassisAccelVec = chassisForceVec.div(config.massKG);


### PR DESCRIPTION
This prevents Rotation2d from screaming in the console from both x and y being 0 when the module isn't applying a force.