### PR TITLE
Modified swerve setpoint generator to use the correct torque limit fo…

### DIFF
--- a/pathplannerlib-python/pathplannerlib/util/swerve.py
+++ b/pathplannerlib-python/pathplannerlib/util/swerve.py
@@ -221,11 +221,13 @@ class SwerveSetpointGenerator:
                 / self._config.moduleConfig.wheelRadiusMeters
             # Use the current battery voltage since we won't be able to supply 12v if the
             # battery is sagging down to 11v, which will affect the max torque output
-            current_draw = \
-                self._config.moduleConfig.driveMotor.current(
-                    math.fabs(last_vel_rad_per_sec), input_voltage)
+            current_draw = self._config.moduleConfig.driveMotor.current(abs(last_vel_rad_per_sec), input_voltage)
+            reverse_current_draw = abs(
+                self._config.moduleConfig.driveMotor.getCurrent(abs(last_vel_rad_per_sec), -input_voltage))
             current_draw = min(current_draw, self._config.moduleConfig.driveCurrentLimit)
-            module_torque = self._config.moduleConfig.driveMotor.torque(current_draw)
+            reverse_current_draw = min(reverse_current_draw, self._config.moduleConfig.driveCurrentLimit)
+            forward_module_torque = self._config.moduleConfig.driveMotor.torque(current_draw)
+            reverse_module_torque = self._config.moduleConfig.driveMotor.torque(reverse_current_draw)
 
             prev_speed = prev_setpoint.module_states[m].speed
             desired_module_states[m].optimize(prev_setpoint.module_states[m].angle)
@@ -233,15 +235,18 @@ class SwerveSetpointGenerator:
 
             force_sign = 1
             force_angle = prev_setpoint.module_states[m].angle
+            module_torque = 0.0
             if self._epsilonEquals(prev_speed, 0.0) \
                     or (prev_speed > 0 and desired_speed >= prev_speed) \
                     or (prev_speed < 0 and desired_speed <= prev_speed):
+                module_torque = forward_module_torque
                 # Torque loss will be fighting motor
                 module_torque -= self._config.moduleConfig.torqueLoss
                 force_sign = 1  # Force will be applied in direction of module
                 if prev_speed < 0:
                     force_angle = force_angle + Rotation2d(math.pi)
             else:
+                module_torque = reverse_module_torque
                 # Torque loss will be helping the motor
                 module_torque += self._config.moduleConfig.torqueLoss
                 force_sign = -1  # Force will be applied in opposite direction of module

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/util/swerve/SwerveSetpointGenerator.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/util/swerve/SwerveSetpointGenerator.java
@@ -253,7 +253,8 @@ public class SwerveSetpointGenerator {
       double currentDraw =
           config.moduleConfig.driveMotor.getCurrent(Math.abs(lastVelRadPerSec), inputVoltage);
       double reverseCurrentDraw =
-          Math.abs(config.moduleConfig.driveMotor.getCurrent(Math.abs(lastVelRadPerSec), -inputVoltage));
+          Math.abs(
+              config.moduleConfig.driveMotor.getCurrent(Math.abs(lastVelRadPerSec), -inputVoltage));
       currentDraw = Math.min(currentDraw, config.moduleConfig.driveCurrentLimit);
       reverseCurrentDraw = Math.min(reverseCurrentDraw, config.moduleConfig.driveCurrentLimit);
       double forwardModuleTorque = config.moduleConfig.driveMotor.getTorque(currentDraw);

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/util/swerve/SwerveSetpointGenerator.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/util/swerve/SwerveSetpointGenerator.java
@@ -252,8 +252,12 @@ public class SwerveSetpointGenerator {
       // battery is sagging down to 11v, which will affect the max torque output
       double currentDraw =
           config.moduleConfig.driveMotor.getCurrent(Math.abs(lastVelRadPerSec), inputVoltage);
+      double reverseCurrentDraw =
+          Math.abs(config.moduleConfig.driveMotor.getCurrent(Math.abs(lastVelRadPerSec), -inputVoltage));
       currentDraw = Math.min(currentDraw, config.moduleConfig.driveCurrentLimit);
-      double moduleTorque = config.moduleConfig.driveMotor.getTorque(currentDraw);
+      reverseCurrentDraw = Math.min(reverseCurrentDraw, config.moduleConfig.driveCurrentLimit);
+      double forwardModuleTorque = config.moduleConfig.driveMotor.getTorque(currentDraw);
+      double reverseModuleTorque = config.moduleConfig.driveMotor.getTorque(reverseCurrentDraw);
 
       double prevSpeed = prevSetpoint.moduleStates()[m].speedMetersPerSecond;
       desiredModuleStates[m].optimize(prevSetpoint.moduleStates()[m].angle);
@@ -261,9 +265,11 @@ public class SwerveSetpointGenerator {
 
       int forceSign;
       Rotation2d forceAngle = prevSetpoint.moduleStates()[m].angle;
+      double moduleTorque;
       if (epsilonEquals(prevSpeed, 0.0)
           || (prevSpeed > 0 && desiredSpeed >= prevSpeed)
           || (prevSpeed < 0 && desiredSpeed <= prevSpeed)) {
+        moduleTorque = forwardModuleTorque;
         // Torque loss will be fighting motor
         moduleTorque -= config.moduleConfig.torqueLoss;
         forceSign = 1; // Force will be applied in direction of module
@@ -271,6 +277,7 @@ public class SwerveSetpointGenerator {
           forceAngle = forceAngle.plus(Rotation2d.k180deg);
         }
       } else {
+        moduleTorque = reverseModuleTorque;
         // Torque loss will be helping the motor
         moduleTorque += config.moduleConfig.torqueLoss;
         forceSign = -1; // Force will be applied in opposite direction of module


### PR DESCRIPTION
…r motors when decelerating.

Modified swerve setpoint generator to use the correct torque limit for motors when decelerating instead of using the incorrect acceleration torque limit.

This should fix an issue where the setpoint generator decelerates way slower than it should/could, and also gets stuck at max speed occasionally. #947 