### PR TITLE
[Swerve Setpoint Generator] Raise kEpsilon from 1e-8 to 1e-6

### DIFF
--- a/pathplannerlib-python/pathplannerlib/util/swerve.py
+++ b/pathplannerlib-python/pathplannerlib/util/swerve.py
@@ -24,7 +24,7 @@ class SwerveSetpointGenerator:
     kinematic constraints on module rotation and wheel velocity/torque, as well as preventing any 
     forces acting on a module's wheel from exceeding the force of friction.
     """
-    _k_epsilon = 1e-8
+    _k_epsilon = 1e-6
 
     def __init__(self, config: RobotConfig, max_steer_velocity_rads_per_sec: float) -> None:
         """

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/util/swerve/SwerveSetpointGenerator.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/util/swerve/SwerveSetpointGenerator.java
@@ -25,7 +25,7 @@ import java.util.Optional;
  * forces acting on a module's wheel from exceeding the force of friction.
  */
 public class SwerveSetpointGenerator {
-  private static final double kEpsilon = 1E-8;
+  private static final double kEpsilon = 1E-6;
 
   private final RobotConfig config;
   private final double maxSteerVelocityRadsPerSec;


### PR DESCRIPTION
This prevents an extremely rare but still possible warning from Rotation2d about x and y being 0, as Rotation2d uses 1e-6 as its epsilon for 0 checking.