### PR TITLE
Fix typo in IdealStartingState Javadoc (#1007)

### DIFF
--- a/pathplannerlib-python/pathplannerlib/path.py
+++ b/pathplannerlib-python/pathplannerlib/path.py
@@ -109,7 +109,7 @@ class GoalEndState:
 @dataclass(frozen=True)
 class IdealStartingState:
     """
-    Describes the ideal starting state of the robot when finishing a path
+    Describes the ideal starting state of the robot when starting a path
 
     Args:
         velocity (float): The ideal starting velocity (M/S)

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/path/IdealStartingState.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/path/IdealStartingState.java
@@ -8,14 +8,14 @@ import edu.wpi.first.units.measure.LinearVelocity;
 import org.json.simple.JSONObject;
 
 /**
- * Describes the ideal starting state of the robot when finishing a path
+ * Describes the ideal starting state of the robot when starting a path
  *
  * @param velocityMPS The ideal starting velocity (M/S)
  * @param rotation The ideal starting rotation
  */
 public record IdealStartingState(double velocityMPS, Rotation2d rotation) {
   /**
-   * Describes the ideal starting state of the robot when finishing a path
+   * Describes the ideal starting state of the robot when starting a path
    *
    * @param velocity The ideal starting velocity
    * @param rotation The ideal starting rotation


### PR DESCRIPTION
I believe I've fixed the typo.

If there could be more clarification added, I'd be interested. I find the term "Ideal" a bit vague. Does it mean the "expected" starting state? That would make sense to me since I'm using it for on-the-fly generation, but I'm not sure if there are other use cases of the class.