### PR TITLE
Prevent crash when generating a trajectory from a one-state path

### DIFF
--- a/pathplannerlib-python/pathplannerlib/trajectory.py
+++ b/pathplannerlib-python/pathplannerlib/trajectory.py
@@ -459,10 +459,13 @@ def _generateStates(states: List[PathPlannerTrajectoryState], path: PathPlannerP
         # Holonomic rotation is interpolated. We use the distance along the path
         # to calculate how much to interpolate since the distribution of path points
         # is not the same along the whole segment
-        t = (path.getPoint(i).distanceAlongPath - path.getPoint(prevRotationTargetIdx).distanceAlongPath) / (
-                path.getPoint(nextRotationTargetIdx).distanceAlongPath - path.getPoint(
-            prevRotationTargetIdx).distanceAlongPath)
-        holonomicRot = _cosineInterpolate(prevRotationTargetRot, nextRotationTargetRot, t)
+        if prevRotationTargetIdx != nextRotationTargetIdx:
+            t = (path.getPoint(i).distanceAlongPath - path.getPoint(prevRotationTargetIdx).distanceAlongPath) / (
+                    path.getPoint(nextRotationTargetIdx).distanceAlongPath - path.getPoint(
+                prevRotationTargetIdx).distanceAlongPath)
+            holonomicRot = _cosineInterpolate(prevRotationTargetRot, nextRotationTargetRot, t)
+        else:
+            holonomicRot = nextRotationTargetRot
 
         robotPose = Pose2d(p.position, holonomicRot)
         state = PathPlannerTrajectoryState()

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/trajectory/PathPlannerTrajectory.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/trajectory/PathPlannerTrajectory.java
@@ -235,15 +235,21 @@ public class PathPlannerTrajectory {
         nextRotationTargetRot = path.getPoint(nextRotationTargetIdx).rotationTarget.rotation();
       }
 
-      // Holonomic rotation is interpolated. We use the distance along the path
-      // to calculate how much to interpolate since the distribution of path points
-      // is not the same along the whole segment
-      double t =
-          (path.getPoint(i).distanceAlongPath
-                  - path.getPoint(prevRotationTargetIdx).distanceAlongPath)
-              / (path.getPoint(nextRotationTargetIdx).distanceAlongPath
-                  - path.getPoint(prevRotationTargetIdx).distanceAlongPath);
-      Rotation2d holonomicRot = cosineInterpolate(prevRotationTargetRot, nextRotationTargetRot, t);
+      Rotation2d holonomicRot;
+      if (prevRotationTargetIdx != nextRotationTargetIdx) {
+        // Holonomic rotation is interpolated. We use the distance along the path
+        // to calculate how much to interpolate since the distribution of path points
+        // is not the same along the whole segment
+        double t =
+            (path.getPoint(i).distanceAlongPath
+                    - path.getPoint(prevRotationTargetIdx).distanceAlongPath)
+                / (path.getPoint(nextRotationTargetIdx).distanceAlongPath
+                    - path.getPoint(prevRotationTargetIdx).distanceAlongPath);
+        holonomicRot = cosineInterpolate(prevRotationTargetRot, nextRotationTargetRot, t);
+      } else {
+        // If both rotation targets fall on the same point, just use the next one.
+        holonomicRot = nextRotationTargetRot;
+      }
 
       Pose2d robotPose = new Pose2d(p.position, holonomicRot);
       var state = new PathPlannerTrajectoryState();


### PR DESCRIPTION
When a path is generated which only contains a single state (`PathPlannerPath.numPoints() == 1`), generating a trajectory crashes, as seen in #1056. This is caused by the interpolation between holonomic drivetrain rotations, which is trying to interpolate between two identical points, which have a distance of 0 apart from each other, thus causing a divide-by-zero.

When two path rotation targets fall on the same path point (as would be seen when there is only one point, and perhaps could be created by some other malformed path), instead of trying to interpolate between them, this fix just uses the rotation value for the next point.