### PR TITLE
Increase precision to 4 of numeric values

### DIFF
--- a/lib/widgets/number_text_field.dart
+++ b/lib/widgets/number_text_field.dart
@@ -27,7 +27,7 @@ class NumberTextField extends StatelessWidget {
     this.arrowKeyIncrement = 0.01,
     this.minValue,
     this.maxValue,
-    this.precision = 3,
+    this.precision = 4,
     TextEditingController? controller,
   }) {
     _controller = controller ?? TextEditingController();


### PR DESCRIPTION
Our team needs to have more precise values for several things in our Robot Settings, especially in the new ReefScape season. Hopefully this will allow PathPlanner autos to be even more accurate than they already are.