### PR TITLE
Fix pathfindToPose crashing with nonzero goal end velocity in Python

### DIFF
--- a/pathplannerlib-python/pathplannerlib/trajectory.py
+++ b/pathplannerlib-python/pathplannerlib/trajectory.py
@@ -201,7 +201,7 @@ class PathPlannerTrajectory:
                 _forwardAccelPass(self._states, config)
 
                 # Set the final module velocities
-                endSpeedTrans = Translation2d(path.getGoalEndState().velocity, self._states[-1].heading)
+                endSpeedTrans = Translation2d(distance=path.getGoalEndState().velocity, angle=self._states[-1].heading)
                 endFieldSpeeds = ChassisSpeeds(endSpeedTrans.x, endSpeedTrans.y, 0.0)
                 endStates = config.toSwerveModuleStates(ChassisSpeeds.fromFieldRelativeSpeeds(endFieldSpeeds,
                                                                                               self._states[


### PR DESCRIPTION
The title describes the commit. This crash occured because a Translation2d (in line 204 of the trajectory.py file) was being constructed with a float and a Rotation2d and no keyword arguments, which it doesn't like. I just added keyword arguments, which fixes the crash.

This is my first pull request to an actual project, so please forgive any errors :D