### PR TITLE
Navgrid Based Start Tolerance for Pathfinding

### DIFF
--- a/pathplannerlib/src/main/java/com/pathplanner/lib/commands/PathfindingCommand.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/commands/PathfindingCommand.java
@@ -292,7 +292,7 @@ public class PathfindingCommand extends Command {
             && currentPose
                     .getTranslation()
                     .getDistance(currentTrajectory.getEndState().pose.getTranslation())
-                < 2.0;
+                < (Pathfinding.getNavgridSize()*4);
 
     if (!skipUpdates && Pathfinding.isNewPathAvailable()) {
       currentPath = Pathfinding.getCurrentPath(constraints, goalEndState);

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/commands/PathfindingCommand.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/commands/PathfindingCommand.java
@@ -262,7 +262,10 @@ public class PathfindingCommand extends Command {
       }
     }
 
-    if (currentPose.getTranslation().getDistance(targetPose.getTranslation()) < 0.5) {
+    if (currentPose.getTranslation().getDistance(targetPose.getTranslation())
+        < (Pathfinding.getNavgridSize() * Math.sqrt(2))) {
+      // This finds the max distance in your current navgrid and makes sure that it cannot pathfind
+      // to itself.
       output.accept(new ChassisSpeeds(), DriveFeedforwards.zeros(robotConfig.numModules));
       finish = true;
     } else {

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/pathfinding/Pathfinding.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/pathfinding/Pathfinding.java
@@ -28,7 +28,11 @@ public class Pathfinding {
   public static void setPathfinder(Pathfinder pathfinder) {
     Pathfinding.pathfinder = pathfinder;
   }
-
+   /**
+   * Get the current navgrid size from the navgrid.json file in deploy
+   *
+   * @return Navgrid size (double)
+   */
   public static double getNavgridSize() {
     File navGridFile = new File(Filesystem.getDeployDirectory(), "pathplanner/navgrid.json");
     if (navGridFile.exists()) {

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/pathfinding/Pathfinding.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/pathfinding/Pathfinding.java
@@ -5,7 +5,13 @@ import com.pathplanner.lib.path.PathConstraints;
 import com.pathplanner.lib.path.PathPlannerPath;
 import edu.wpi.first.math.Pair;
 import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.wpilibj.Filesystem;
+import java.io.BufferedReader;
+import java.io.File;
+import java.io.FileReader;
 import java.util.List;
+import org.json.simple.JSONObject;
+import org.json.simple.parser.JSONParser;
 
 /**
  * Static class for interacting with the chosen pathfinding implementation from the pathfinding
@@ -21,6 +27,28 @@ public class Pathfinding {
    */
   public static void setPathfinder(Pathfinder pathfinder) {
     Pathfinding.pathfinder = pathfinder;
+  }
+
+  public static double getNavgridSize() {
+    File navGridFile = new File(Filesystem.getDeployDirectory(), "pathplanner/navgrid.json");
+    if (navGridFile.exists()) {
+      try (BufferedReader br = new BufferedReader(new FileReader(navGridFile))) {
+        StringBuilder fileContentBuilder = new StringBuilder();
+        String line;
+        while ((line = br.readLine()) != null) {
+          fileContentBuilder.append(line);
+        }
+
+        String fileContent = fileContentBuilder.toString();
+        JSONObject json = (JSONObject) new JSONParser().parse(fileContent);
+
+        return ((Number) json.get("nodeSizeMeters")).doubleValue();
+
+      } catch (Exception e) {
+        return 0.3;
+      }
+    }
+    return 0.3;
   }
 
   /** Ensure that a pathfinding implementation has been chosen. If not, set it to the default. */


### PR DESCRIPTION
Changed the minimum start distance from a hardcoded 0.5 to the diagonal of the current navgrid size. 