### PR TITLE
Upgrade Spotless to 6.23.3

### DIFF
--- a/pathplannerlib/build.gradle
+++ b/pathplannerlib/build.gradle
@@ -6,7 +6,7 @@ plugins {
     id 'edu.wpi.first.NativeUtils' version '2026.0.0'
     id 'edu.wpi.first.GradleJni' version '1.1.0'
     id 'edu.wpi.first.GradleVsCode' version '2.1.0'
-    id 'com.diffplug.spotless' version '6.11.0'
+    id 'com.diffplug.spotless' version '6.23.3'
     id 'jacoco'
 }
 
@@ -125,7 +125,7 @@ spotless {
             exclude '**/build/**', '**/build-*/**'
         }
         toggleOffOn()
-        googleJavaFormat()
+        googleJavaFormat('1.10.0')
         removeUnusedImports()
         trimTrailingWhitespace()
         endWithNewline()

--- a/pathplannerlib/config.gradle
+++ b/pathplannerlib/config.gradle
@@ -149,7 +149,6 @@ ext.createAllCombined = { list, name, base, type, project ->
     }
 
     return task
-
 }
 
 ext.includeStandardZipFormat = { task, value ->


### PR DESCRIPTION
This resolves java.lang.NoSuchMethodError when running google-java-format (see https://github.com/palantir/palantir-java-format/issues/943).

There are more recent versions of Spotless, but they would result in larger
reformatting of the pathplanner code.