### PR TITLE
examples: update gradle wrapper to 8.9

### DIFF
--- a/examples/cpp/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/cpp/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,7 @@
+#Wed Mar 25 11:02:01 EDT 2026
 distributionBase=GRADLE_USER_HOME
 distributionPath=permwrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/examples/java/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/java/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=permwrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.9-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
Prevents the Java extension from getting angry.

Signed-off-by: crueter <crueter@eden-emu.dev>
