### PR TITLE
Make PathPlannerPath more tolerant of tight curves

### DIFF
--- a/pathplannerlib-python/pathplannerlib/path.py
+++ b/pathplannerlib-python/pathplannerlib/path.py
@@ -1206,6 +1206,12 @@ class PathPlannerPath:
                 rotation = angleToTarget + pointZone.rotationOffset
                 points[i].rotationTarget = RotationTarget(points[i].waypointRelativePos, rotation)
 
+            curveLen = points[i - 1].position.distance(points[i + 1].position)
+
+            if curveLen < 0.05:
+                # Prevent oversampling points that are very close together
+                continue
+
             curveRadius = calculateRadius(points[i - 1].position, points[i].position, points[i + 1].position)
 
             if not math.isfinite(curveRadius):

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/path/PathPlannerPath.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/path/PathPlannerPath.java
@@ -901,6 +901,14 @@ public class PathPlannerPath {
             new RotationTarget(points.get(i).waypointRelativePos, rotation);
       }
 
+      double curveLen =
+          points.get(i - 1).position.getDistance(points.get(i + 1).position);
+
+      if (curveLen < 0.05) {
+          // Prevent oversampling points that are very close together
+          continue;
+      }
+
       double curveRadius =
           GeometryUtil.calculateRadius(
               points.get(i - 1).position, points.get(i).position, points.get(i + 1).position);

--- a/pathplannerlib/src/main/native/cpp/pathplanner/lib/path/PathPlannerPath.cpp
+++ b/pathplannerlib/src/main/native/cpp/pathplanner/lib/path/PathPlannerPath.cpp
@@ -558,6 +558,14 @@ std::vector<PathPoint> PathPlannerPath::createPath() {
 					points[i].waypointRelativePos, rotation);
 		}
 
+        units::meter_t curveLen =
+            points[i - 1].position.Distance(points[i + 1].position);
+
+        if (curveLen < 0.05_m) {
+            // Prevent oversampling points that are very close together
+            continue;
+        }
+
 		units::meter_t curveRadius = GeometryUtil::calculateRadius(
 				points[i - 1].position, points[i].position,
 				points[i + 1].position);


### PR DESCRIPTION
This solves an issue reported on Discord with https://github.com/mnth-titan-robotics/titan-2026/blob/0261f8905e35cfb78d25f9a399308d6d201ab98b/deploy/pathplanner/autos/Left_SweepShoot.auto

### Problem
The path doesn't appear to have any excessively sharp turns in the UI. When running the Auto the Intake doesn't run, and the robot starts shooting at around the 0.7s mark rather than at the end of the Auto. Stepping through path generation shows that it's over-sampling the path near the beginning, causing several points very close together. The PathPlannerTrajectory constructor sets the `timeSeconds` of all these points to the same value causing it to trigger all `unaddedEvents` simultaneously.

### Fix
`PathPlannerPath._createPath` detects any points with a tight (< 0.5m) radius and inserts additional points to provide finer control. This change skips this resampling step if the points are very close (within 5cm). 