### PR TITLE
feat: add AutoBuilder.configureDistanceBased for distance-based mode

### DIFF
--- a/pathplannerlib/src/main/java/com/pathplanner/lib/auto/AutoBuilder.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/auto/AutoBuilder.java
@@ -140,6 +140,175 @@ public class AutoBuilder {
   }
 
   /**
+   * Configures the AutoBuilder to follow paths by projected arc length instead of elapsed time. The
+   * robot's pose is projected onto the path each cycle, and the controller targets the state at
+   * that arc length. Useful when disturbances (obstacles, contact, momentary slippage) would cause
+   * a time-based reference to race ahead of the actual robot progress.
+   *
+   * <p>Pathfinding is <strong>not</strong> configured by this method — distance-based mode supports
+   * direct path following only. For pathfinding workflows, use the time-based {@link
+   * #configure(Supplier, Consumer, Supplier, BiConsumer, PathFollowingController, RobotConfig,
+   * BooleanSupplier, Subsystem...)} method.
+   *
+   * @param poseSupplier a supplier for the robot's current pose
+   * @param resetPose a consumer for resetting the robot's pose
+   * @param robotRelativeSpeedsSupplier a supplier for the robot's current robot relative chassis
+   *     speeds
+   * @param output Output function that accepts robot-relative ChassisSpeeds and feedforwards for
+   *     each drive motor.
+   * @param controller Path following controller (typically {@link
+   *     com.pathplanner.lib.controllers.PPCrossTrackHolonomicController})
+   * @param robotConfig The robot configuration
+   * @param endConditions End-of-path tolerances. Use {@link
+   *     FollowPathDistanceCommand.EndConditions#defaults()} for sane defaults.
+   * @param shouldFlipPath Supplier that determines if paths should be flipped to the other side of
+   *     the field. This will maintain a global blue alliance origin.
+   * @param driveRequirements the subsystem requirements for the robot's drive train
+   */
+  public static void configureDistanceBased(
+      Supplier<Pose2d> poseSupplier,
+      Consumer<Pose2d> resetPose,
+      Supplier<ChassisSpeeds> robotRelativeSpeedsSupplier,
+      BiConsumer<ChassisSpeeds, DriveFeedforwards> output,
+      PathFollowingController controller,
+      RobotConfig robotConfig,
+      FollowPathDistanceCommand.EndConditions endConditions,
+      BooleanSupplier shouldFlipPath,
+      Subsystem... driveRequirements) {
+    if (globals.configured) {
+      DriverStation.reportError(
+          "Auto builder has already been configured. This is likely in error.", true);
+    }
+
+    globals.pathFollowingCommandBuilder =
+        (path) ->
+            new FollowPathDistanceCommand(
+                path,
+                poseSupplier,
+                robotRelativeSpeedsSupplier,
+                output,
+                controller,
+                robotConfig,
+                shouldFlipPath,
+                endConditions,
+                driveRequirements);
+    globals.poseSupplier = poseSupplier;
+    globals.resetPose = resetPose;
+    globals.configured = true;
+    globals.shouldFlipPath = shouldFlipPath;
+    globals.isHolonomic = robotConfig.isHolonomic;
+    // Pathfinding is not configured for distance-based mode -- PathfindingCommand is
+    // intrinsically time-based and integrating distance-based pathfinding is a separate concern.
+    globals.pathfindingConfigured = false;
+  }
+
+  /**
+   * Configures the AutoBuilder for distance-based path following using {@link
+   * FollowPathDistanceCommand.EndConditions#defaults()}.
+   *
+   * @param poseSupplier a supplier for the robot's current pose
+   * @param resetPose a consumer for resetting the robot's pose
+   * @param robotRelativeSpeedsSupplier a supplier for the robot's current robot relative chassis
+   *     speeds
+   * @param output Output function for robot-relative ChassisSpeeds and per-module feedforwards.
+   * @param controller Path following controller
+   * @param robotConfig The robot configuration
+   * @param shouldFlipPath Supplier that determines if paths should be flipped
+   * @param driveRequirements the subsystem requirements for the robot's drive train
+   */
+  public static void configureDistanceBased(
+      Supplier<Pose2d> poseSupplier,
+      Consumer<Pose2d> resetPose,
+      Supplier<ChassisSpeeds> robotRelativeSpeedsSupplier,
+      BiConsumer<ChassisSpeeds, DriveFeedforwards> output,
+      PathFollowingController controller,
+      RobotConfig robotConfig,
+      BooleanSupplier shouldFlipPath,
+      Subsystem... driveRequirements) {
+    configureDistanceBased(
+        poseSupplier,
+        resetPose,
+        robotRelativeSpeedsSupplier,
+        output,
+        controller,
+        robotConfig,
+        FollowPathDistanceCommand.EndConditions.defaults(),
+        shouldFlipPath,
+        driveRequirements);
+  }
+
+  /**
+   * Configures the AutoBuilder for distance-based path following without per-module feedforwards.
+   *
+   * @param poseSupplier a supplier for the robot's current pose
+   * @param resetPose a consumer for resetting the robot's pose
+   * @param robotRelativeSpeedsSupplier a supplier for the robot's current robot relative chassis
+   *     speeds
+   * @param output Output function that accepts robot-relative ChassisSpeeds.
+   * @param controller Path following controller
+   * @param robotConfig The robot configuration
+   * @param endConditions End-of-path tolerances
+   * @param shouldFlipPath Supplier that determines if paths should be flipped
+   * @param driveRequirements the subsystem requirements for the robot's drive train
+   */
+  public static void configureDistanceBased(
+      Supplier<Pose2d> poseSupplier,
+      Consumer<Pose2d> resetPose,
+      Supplier<ChassisSpeeds> robotRelativeSpeedsSupplier,
+      Consumer<ChassisSpeeds> output,
+      PathFollowingController controller,
+      RobotConfig robotConfig,
+      FollowPathDistanceCommand.EndConditions endConditions,
+      BooleanSupplier shouldFlipPath,
+      Subsystem... driveRequirements) {
+    configureDistanceBased(
+        poseSupplier,
+        resetPose,
+        robotRelativeSpeedsSupplier,
+        (speeds, feedforwards) -> output.accept(speeds),
+        controller,
+        robotConfig,
+        endConditions,
+        shouldFlipPath,
+        driveRequirements);
+  }
+
+  /**
+   * Configures the AutoBuilder for distance-based path following with default end conditions and
+   * without per-module feedforwards.
+   *
+   * @param poseSupplier a supplier for the robot's current pose
+   * @param resetPose a consumer for resetting the robot's pose
+   * @param robotRelativeSpeedsSupplier a supplier for the robot's current robot relative chassis
+   *     speeds
+   * @param output Output function that accepts robot-relative ChassisSpeeds.
+   * @param controller Path following controller
+   * @param robotConfig The robot configuration
+   * @param shouldFlipPath Supplier that determines if paths should be flipped
+   * @param driveRequirements the subsystem requirements for the robot's drive train
+   */
+  public static void configureDistanceBased(
+      Supplier<Pose2d> poseSupplier,
+      Consumer<Pose2d> resetPose,
+      Supplier<ChassisSpeeds> robotRelativeSpeedsSupplier,
+      Consumer<ChassisSpeeds> output,
+      PathFollowingController controller,
+      RobotConfig robotConfig,
+      BooleanSupplier shouldFlipPath,
+      Subsystem... driveRequirements) {
+    configureDistanceBased(
+        poseSupplier,
+        resetPose,
+        robotRelativeSpeedsSupplier,
+        output,
+        controller,
+        robotConfig,
+        FollowPathDistanceCommand.EndConditions.defaults(),
+        shouldFlipPath,
+        driveRequirements);
+  }
+
+  /**
    * Holder for all global variables directly referenced by AutoBuilder.
    *
    * <p>This class exists to ensure that {@link #resetForTesting()} resets all static state in

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/commands/FollowPathDistanceCommand.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/commands/FollowPathDistanceCommand.java
@@ -67,16 +67,25 @@ public class FollowPathDistanceCommand extends Command {
     }
   }
 
-  // Projection: lookahead window in number of state-array segments. PathPlanner state spacing is
-  // roughly 5 cm, so 6 segments = ~30 cm. Tight enough to reject odometry glitches, wide enough to
-  // not lose the path during fast moves at 50 Hz.
+  // Closest-point projection window, in state segments (~5 cm each). Wide enough for 50 Hz moves.
   private static final int LOOKAHEAD_SEGMENTS = 6;
-  // Big-gap fallback: if the best closest-point distance in the lookahead window exceeds this,
-  // run a full-path scan to recover (e.g. after odometry reset or large disturbance).
+  // If the best closest-point distance in the window exceeds this, fall back to a full-path scan.
   private static final double BIG_GAP_THRESHOLD_M = 0.5;
-  // Maximum advance in arc length per execute() tick. Caps single-frame projection jumps that
-  // would otherwise let odometry spikes race the target state ahead.
+  // Max projection advance per execute(); caps single-frame jumps from odometry spikes.
   private static final double MAX_DELTA_S_PER_TICK = 0.3;
+
+  // Velocity-FF override at planner-stopping samples. At v=0 samples the planned FF, position
+  // errors, and curvature FF are all zero, so the controller outputs nothing and the chassis
+  // can't leave the sample. When local planned v is below threshold and lookahead v is above,
+  // override targetState's velocity FF (linearVelocity + fieldSpeeds) with a blended peek
+  // value; pose/heading/curvature stay at the actual projection so position errors remain
+  // honest. The dual-check correctly stays off at the true path end (both local and lookahead
+  // are low) so the robot is allowed to stop.
+  private static final double BOOTSTRAP_LOOKAHEAD_M = 0.30;
+  // Threshold below which we override. Derived as sqrt(2 * a * lookahead/N): the velocity at
+  // which the post-stop ramp has covered ~lookahead/N meters. N=6 reproduces ~1.0 m/s on a
+  // 10 m/s² ramp (the empirically-tuned default) and adapts to higher/lower accel paths.
+  private static final double BOOTSTRAP_THRESHOLD_RAMP_DIVISOR = 6.0;
 
   private final PathPlannerPath originalPath;
   private final Supplier<Pose2d> poseSupplier;
@@ -92,6 +101,7 @@ public class FollowPathDistanceCommand extends Command {
   private PathPlannerTrajectory trajectory;
   private double lastProjectedS;
   private int lastProjectedIdx;
+  private double bootstrapVelocityThresholdMps;
 
   /**
    * Construct a distance-based path-following command.
@@ -217,6 +227,13 @@ public class FollowPathDistanceCommand extends Command {
     lastProjectedIdx = initialProjection.segmentIndex;
     lastProjectedS = initialProjection.arcLength;
 
+    // Derive the bootstrap velocity threshold from this path's max accel. Clamped so an
+    // unlimited-constraint or zero-accel path doesn't produce absurd values.
+    double maxAccel = path.getGlobalConstraints().maxAccelerationMPSSq();
+    if (!Double.isFinite(maxAccel) || maxAccel <= 0.0) maxAccel = 10.0;
+    bootstrapVelocityThresholdMps =
+        Math.sqrt(2.0 * maxAccel * BOOTSTRAP_LOOKAHEAD_M / BOOTSTRAP_THRESHOLD_RAMP_DIVISOR);
+
     eventScheduler.initialize(trajectory);
   }
 
@@ -232,12 +249,33 @@ public class FollowPathDistanceCommand extends Command {
     lastProjectedS = advancedS;
     lastProjectedIdx = p.segmentIndex;
 
-    PathPlannerTrajectoryState targetState = trajectory.sampleByDistance(lastProjectedS);
-
-    ChassisSpeeds targetSpeeds = controller.calculateRobotRelativeSpeeds(currentPose, targetState);
-
     double currentVel =
         Math.hypot(currentSpeeds.vxMetersPerSecond, currentSpeeds.vyMetersPerSecond);
+
+    // See BOOTSTRAP_LOOKAHEAD_M for the override rationale.
+    PathPlannerTrajectoryState targetState = trajectory.sampleByDistance(lastProjectedS);
+    double localV = targetState.linearVelocity;
+    if (localV < bootstrapVelocityThresholdMps) {
+      double peekS =
+          Math.min(lastProjectedS + BOOTSTRAP_LOOKAHEAD_M, trajectory.getTotalArcLength());
+      double peekV = trajectory.sampleByDistance(peekS).linearVelocity;
+      if (peekV >= bootstrapVelocityThresholdMps) {
+        // Blend on localV (not currentVel) so the override tapers with the planned profile
+        // and doesn't chase the chassis as it picks up speed against an at-rest plan.
+        double blend = 1.0 - localV / bootstrapVelocityThresholdMps;
+        double blendedV = localV + (peekV - localV) * blend;
+        // Copy before mutating: sampleByDistance can return cached endpoint references.
+        targetState = targetState.copyWithTime(targetState.timeSeconds);
+        targetState.linearVelocity = blendedV;
+        double cosH = targetState.heading.getCos();
+        double sinH = targetState.heading.getSin();
+        targetState.fieldSpeeds =
+            new ChassisSpeeds(
+                blendedV * cosH, blendedV * sinH, targetState.fieldSpeeds.omegaRadiansPerSecond);
+      }
+    }
+
+    ChassisSpeeds targetSpeeds = controller.calculateRobotRelativeSpeeds(currentPose, targetState);
 
     PPLibTelemetry.setCurrentPose(currentPose);
     PathPlannerLogging.logCurrentPose(currentPose);
@@ -261,18 +299,13 @@ public class FollowPathDistanceCommand extends Command {
     boolean nearEnd = lastProjectedS >= totalArc - endConditions.distanceToleranceMeters();
     if (!nearEnd) return false;
 
-    // If the path is a handoff (non-zero end velocity), only the distance gate applies -- we
-    // don't want to wait for the robot to come to a stop. Threshold matches end()'s "is this a
-    // stopping path?" check.
+    // Handoff path (non-zero end velocity): distance gate only, don't wait for full stop.
     if (!isStoppingPath()) return true;
 
     PathPlannerTrajectoryState endState = trajectory.getEndState();
     ChassisSpeeds fieldSpeeds = speedsToFieldFrame();
-    // Gate on TOTAL field-speed magnitude rather than just the tangent component. Using the
-    // tangent projection alone allows isFinished to fire while the cross-track PD is still
-    // closing perpendicular error -- the robot stops with residual lateral offset because the
-    // command exits before cross-track motion completes. Total-magnitude gate ensures the robot
-    // has settled in BOTH directions before declaring finished.
+    // Total-magnitude gate (not tangent component) so we don't fire while cross-track PD is
+    // still closing perpendicular error.
     double totalSpeed = Math.hypot(fieldSpeeds.vxMetersPerSecond, fieldSpeeds.vyMetersPerSecond);
     boolean velocityOk = totalSpeed < endConditions.velocityToleranceMPS();
 
@@ -314,19 +347,16 @@ public class FollowPathDistanceCommand extends Command {
     int windowEnd = Math.min(n - 2, lastProjectedIdx + LOOKAHEAD_SEGMENTS);
     Projection best = scanWindow(robotPos, states, windowStart, windowEnd);
 
-    // If the best projection saturated to the forward edge of the window, scan one more window
-    // forward to handle fast moves that crossed multiple states in one tick.
+    // Saturated at the forward edge: extend one window to catch fast multi-state moves.
     if (best.segmentIndex == windowEnd && best.segmentU >= 0.99 && windowEnd < n - 2) {
       int extEnd = Math.min(n - 2, windowEnd + LOOKAHEAD_SEGMENTS);
       Projection extended = scanWindow(robotPos, states, windowEnd, extEnd);
       if (extended.distance < best.distance) best = extended;
     }
 
-    // Big-gap fallback: distance unreasonable, fall back to full scan.
+    // Window match too far: full scan, but only accept it if it's both closer and not backward.
     if (best.distance > BIG_GAP_THRESHOLD_M) {
       Projection fullScan = fullScan(robotPos);
-      // Only accept the full-scan result if it's strictly better and meaningfully forward of the
-      // window result (avoid jumping backward to a closer segment behind us).
       if (fullScan.distance < best.distance && fullScan.arcLength >= lastProjectedS) {
         best = fullScan;
       }
@@ -340,12 +370,7 @@ public class FollowPathDistanceCommand extends Command {
     return scanWindow(robotPos, states, 0, states.size() - 2);
   }
 
-  /**
-   * Closest-point-on-polyline over a segment range [startIdx, endIdx] (inclusive). For each segment
-   * (states[i], states[i+1]), compute the closest point on that line segment to robotPos via
-   * closed-form projection clamped to [0, 1]. Return the best (segmentIndex, segmentU, arcLength,
-   * distance). Package-private static so tests can exercise the real implementation.
-   */
+  /** Closest-point-on-polyline over a segment range. Package-private static for testing. */
   static Projection scanWindow(
       Translation2d robotPos, List<PathPlannerTrajectoryState> states, int startIdx, int endIdx) {
     int bestIdx = startIdx;

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/commands/FollowPathDistanceCommand.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/commands/FollowPathDistanceCommand.java
@@ -267,11 +267,14 @@ public class FollowPathDistanceCommand extends Command {
     if (!isStoppingPath()) return true;
 
     PathPlannerTrajectoryState endState = trajectory.getEndState();
-    double tx = endState.heading.getCos();
-    double ty = endState.heading.getSin();
     ChassisSpeeds fieldSpeeds = speedsToFieldFrame();
-    double alongTangent = fieldSpeeds.vxMetersPerSecond * tx + fieldSpeeds.vyMetersPerSecond * ty;
-    boolean velocityOk = Math.abs(alongTangent) < endConditions.velocityToleranceMPS();
+    // Gate on TOTAL field-speed magnitude rather than just the tangent component. Using the
+    // tangent projection alone allows isFinished to fire while the cross-track PD is still
+    // closing perpendicular error -- the robot stops with residual lateral offset because the
+    // command exits before cross-track motion completes. Total-magnitude gate ensures the robot
+    // has settled in BOTH directions before declaring finished.
+    double totalSpeed = Math.hypot(fieldSpeeds.vxMetersPerSecond, fieldSpeeds.vyMetersPerSecond);
+    boolean velocityOk = totalSpeed < endConditions.velocityToleranceMPS();
 
     double headingErr =
         Math.abs(poseSupplier.get().getRotation().minus(endState.pose.getRotation()).getRadians());

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/commands/FollowPathDistanceCommand.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/commands/FollowPathDistanceCommand.java
@@ -1,0 +1,406 @@
+package com.pathplanner.lib.commands;
+
+import com.pathplanner.lib.config.RobotConfig;
+import com.pathplanner.lib.controllers.PathFollowingController;
+import com.pathplanner.lib.events.EventScheduler;
+import com.pathplanner.lib.path.PathPlannerPath;
+import com.pathplanner.lib.trajectory.PathPlannerTrajectory;
+import com.pathplanner.lib.trajectory.PathPlannerTrajectoryState;
+import com.pathplanner.lib.util.DriveFeedforwards;
+import com.pathplanner.lib.util.PPLibTelemetry;
+import com.pathplanner.lib.util.PathPlannerLogging;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.kinematics.ChassisSpeeds;
+import edu.wpi.first.wpilibj2.command.Command;
+import edu.wpi.first.wpilibj2.command.Subsystem;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.function.BiConsumer;
+import java.util.function.BooleanSupplier;
+import java.util.function.Supplier;
+
+/**
+ * Path-following command that drives by projected arc length instead of elapsed time. On each
+ * cycle, the robot's current pose is projected onto the path, the controller is given the target
+ * state at that arc length, and the path finishes when the robot has reached the end position (with
+ * optional velocity and rotation gates).
+ *
+ * <p>Useful when a time-based reference would race ahead during disturbances (obstacles, contact
+ * with a game piece, momentary slippage). The target state always reflects where the robot actually
+ * is on the path, so cross-track error is measured at true progress.
+ *
+ * <p>Pairs well with {@link com.pathplanner.lib.controllers.PPCrossTrackHolonomicController}.
+ */
+public class FollowPathDistanceCommand extends Command {
+  /**
+   * End-of-path tolerances. The command finishes when all three conditions are met:
+   *
+   * <ul>
+   *   <li>Projected arc length is within {@code distanceToleranceMeters} of the path end
+   *   <li>Speed component along the path's end tangent is below {@code velocityToleranceMPS}
+   *   <li>Heading error from the path's end rotation is below {@code rotationToleranceRad}
+   * </ul>
+   *
+   * <p>If the path's goal end state has a non-zero velocity (handoff to the next path in an auto),
+   * the velocity and rotation gates are skipped and only the distance gate applies.
+   *
+   * @param distanceToleranceMeters Distance from path end, in meters, below which the path is
+   *     considered "near end".
+   * @param velocityToleranceMPS Maximum allowed speed component along the path's end tangent, in
+   *     m/s.
+   * @param rotationToleranceRad Maximum allowed heading error from the path's end rotation, in
+   *     radians. Set to {@link Double#POSITIVE_INFINITY} to disable the rotation gate.
+   */
+  public record EndConditions(
+      double distanceToleranceMeters, double velocityToleranceMPS, double rotationToleranceRad) {
+    /**
+     * Default tolerances: 5 cm distance, 0.1 m/s along-tangent velocity, 5 degrees rotation. Tuned
+     * for typical FRC swerve scoring positions where small overshoot is unacceptable.
+     *
+     * @return Default end conditions
+     */
+    public static EndConditions defaults() {
+      return new EndConditions(0.05, 0.1, Math.toRadians(5.0));
+    }
+  }
+
+  // Projection: lookahead window in number of state-array segments. PathPlanner state spacing is
+  // roughly 5 cm, so 6 segments = ~30 cm. Tight enough to reject odometry glitches, wide enough to
+  // not lose the path during fast moves at 50 Hz.
+  private static final int LOOKAHEAD_SEGMENTS = 6;
+  // Big-gap fallback: if the best closest-point distance in the lookahead window exceeds this,
+  // run a full-path scan to recover (e.g. after odometry reset or large disturbance).
+  private static final double BIG_GAP_THRESHOLD_M = 0.5;
+  // Maximum advance in arc length per execute() tick. Caps single-frame projection jumps that
+  // would otherwise let odometry spikes race the target state ahead.
+  private static final double MAX_DELTA_S_PER_TICK = 0.3;
+
+  private final PathPlannerPath originalPath;
+  private final Supplier<Pose2d> poseSupplier;
+  private final Supplier<ChassisSpeeds> speedsSupplier;
+  private final BiConsumer<ChassisSpeeds, DriveFeedforwards> output;
+  private final PathFollowingController controller;
+  private final RobotConfig robotConfig;
+  private final BooleanSupplier shouldFlipPath;
+  private final EndConditions endConditions;
+  private final EventScheduler eventScheduler;
+
+  private PathPlannerPath path;
+  private PathPlannerTrajectory trajectory;
+  private double lastProjectedS;
+  private int lastProjectedIdx;
+
+  /**
+   * Construct a distance-based path-following command.
+   *
+   * @param path Path to follow
+   * @param poseSupplier Supplier of the robot's field-relative pose
+   * @param speedsSupplier Supplier of robot-relative chassis speeds
+   * @param output Output sink for robot-relative chassis speeds + per-module feedforwards
+   * @param controller Path-following controller (typically {@link
+   *     com.pathplanner.lib.controllers.PPCrossTrackHolonomicController})
+   * @param robotConfig Robot configuration
+   * @param shouldFlipPath Whether to mirror/rotate the path for the red alliance
+   * @param endConditions End-of-path tolerances (use {@link EndConditions#defaults()} for sane
+   *     defaults)
+   * @param requirements Subsystem requirements, usually just the drive subsystem
+   */
+  public FollowPathDistanceCommand(
+      PathPlannerPath path,
+      Supplier<Pose2d> poseSupplier,
+      Supplier<ChassisSpeeds> speedsSupplier,
+      BiConsumer<ChassisSpeeds, DriveFeedforwards> output,
+      PathFollowingController controller,
+      RobotConfig robotConfig,
+      BooleanSupplier shouldFlipPath,
+      EndConditions endConditions,
+      Subsystem... requirements) {
+    this.originalPath = path;
+    this.poseSupplier = poseSupplier;
+    this.speedsSupplier = speedsSupplier;
+    this.output = output;
+    this.controller = controller;
+    this.robotConfig = robotConfig;
+    this.shouldFlipPath = shouldFlipPath;
+    this.endConditions = endConditions;
+    this.eventScheduler = new EventScheduler();
+
+    Set<Subsystem> driveRequirements = Set.of(requirements);
+    addRequirements(requirements);
+    var eventReqs = EventScheduler.getSchedulerRequirements(this.originalPath);
+    if (!Collections.disjoint(driveRequirements, eventReqs)) {
+      throw new IllegalArgumentException(
+          "Events that are triggered during path following cannot require the drive subsystem");
+    }
+    addRequirements(eventReqs);
+
+    this.path = this.originalPath;
+    Optional<PathPlannerTrajectory> idealTrajectory =
+        this.path.getIdealTrajectory(this.robotConfig);
+    idealTrajectory.ifPresent(traj -> this.trajectory = traj);
+  }
+
+  /**
+   * Convenience constructor using {@link EndConditions#defaults()}.
+   *
+   * @param path Path to follow
+   * @param poseSupplier Supplier of the robot's field-relative pose
+   * @param speedsSupplier Supplier of robot-relative chassis speeds
+   * @param output Output sink for robot-relative chassis speeds + per-module feedforwards
+   * @param controller Path-following controller
+   * @param robotConfig Robot configuration
+   * @param shouldFlipPath Whether to mirror/rotate the path for the red alliance
+   * @param requirements Subsystem requirements
+   */
+  public FollowPathDistanceCommand(
+      PathPlannerPath path,
+      Supplier<Pose2d> poseSupplier,
+      Supplier<ChassisSpeeds> speedsSupplier,
+      BiConsumer<ChassisSpeeds, DriveFeedforwards> output,
+      PathFollowingController controller,
+      RobotConfig robotConfig,
+      BooleanSupplier shouldFlipPath,
+      Subsystem... requirements) {
+    this(
+        path,
+        poseSupplier,
+        speedsSupplier,
+        output,
+        controller,
+        robotConfig,
+        shouldFlipPath,
+        EndConditions.defaults(),
+        requirements);
+  }
+
+  @Override
+  public void initialize() {
+    if (shouldFlipPath.getAsBoolean() && !originalPath.preventFlipping) {
+      path = originalPath.flipPath();
+    } else {
+      path = originalPath;
+    }
+
+    Pose2d currentPose = poseSupplier.get();
+    ChassisSpeeds currentSpeeds = speedsSupplier.get();
+    controller.reset(currentPose, currentSpeeds);
+
+    double linearVel = Math.hypot(currentSpeeds.vxMetersPerSecond, currentSpeeds.vyMetersPerSecond);
+    if (path.getIdealStartingState() != null) {
+      boolean idealVelocity =
+          Math.abs(linearVel - path.getIdealStartingState().velocityMPS()) <= 0.25;
+      boolean idealRotation =
+          !robotConfig.isHolonomic
+              || Math.abs(
+                      currentPose
+                          .getRotation()
+                          .minus(path.getIdealStartingState().rotation())
+                          .getDegrees())
+                  <= 30.0;
+      if (idealVelocity && idealRotation) {
+        trajectory = path.getIdealTrajectory(robotConfig).orElseThrow();
+      } else {
+        trajectory = path.generateTrajectory(currentSpeeds, currentPose.getRotation(), robotConfig);
+      }
+    } else {
+      trajectory = path.generateTrajectory(currentSpeeds, currentPose.getRotation(), robotConfig);
+    }
+
+    PathPlannerLogging.logActivePath(path);
+    PPLibTelemetry.setCurrentPath(path);
+
+    // Initial projection: full scan to handle pose starting anywhere on the path.
+    var initialProjection = fullScan(currentPose.getTranslation());
+    lastProjectedIdx = initialProjection.segmentIndex;
+    lastProjectedS = initialProjection.arcLength;
+
+    eventScheduler.initialize(trajectory);
+  }
+
+  @Override
+  public void execute() {
+    Pose2d currentPose = poseSupplier.get();
+    ChassisSpeeds currentSpeeds = speedsSupplier.get();
+
+    Projection p = projectOntoPath(currentPose.getTranslation());
+    // Monotonic clamp + max-delta-per-tick guard
+    double advancedS = Math.max(lastProjectedS, p.arcLength);
+    advancedS = Math.min(advancedS, lastProjectedS + MAX_DELTA_S_PER_TICK);
+    lastProjectedS = advancedS;
+    lastProjectedIdx = p.segmentIndex;
+
+    PathPlannerTrajectoryState targetState = trajectory.sampleByDistance(lastProjectedS);
+
+    ChassisSpeeds targetSpeeds = controller.calculateRobotRelativeSpeeds(currentPose, targetState);
+
+    double currentVel =
+        Math.hypot(currentSpeeds.vxMetersPerSecond, currentSpeeds.vyMetersPerSecond);
+
+    PPLibTelemetry.setCurrentPose(currentPose);
+    PathPlannerLogging.logCurrentPose(currentPose);
+    PPLibTelemetry.setTargetPose(targetState.pose);
+    PathPlannerLogging.logTargetPose(targetState.pose);
+    PPLibTelemetry.setVelocities(
+        currentVel,
+        targetState.linearVelocity,
+        currentSpeeds.omegaRadiansPerSecond,
+        targetSpeeds.omegaRadiansPerSecond);
+
+    output.accept(targetSpeeds, targetState.feedforwards);
+
+    // Event scheduling uses path time, derived from the projected state's timestamp.
+    eventScheduler.execute(targetState.timeSeconds);
+  }
+
+  @Override
+  public boolean isFinished() {
+    double totalArc = trajectory.getTotalArcLength();
+    boolean nearEnd = lastProjectedS >= totalArc - endConditions.distanceToleranceMeters();
+    if (!nearEnd) return false;
+
+    // If the path is a handoff (non-zero end velocity), only the distance gate applies -- we
+    // don't want to wait for the robot to come to a stop. Threshold matches end()'s "is this a
+    // stopping path?" check.
+    if (!isStoppingPath()) return true;
+
+    PathPlannerTrajectoryState endState = trajectory.getEndState();
+    double tx = endState.heading.getCos();
+    double ty = endState.heading.getSin();
+    ChassisSpeeds fieldSpeeds = speedsToFieldFrame();
+    double alongTangent = fieldSpeeds.vxMetersPerSecond * tx + fieldSpeeds.vyMetersPerSecond * ty;
+    boolean velocityOk = Math.abs(alongTangent) < endConditions.velocityToleranceMPS();
+
+    double headingErr =
+        Math.abs(poseSupplier.get().getRotation().minus(endState.pose.getRotation()).getRadians());
+    boolean rotationOk = headingErr <= endConditions.rotationToleranceRad();
+
+    return velocityOk && rotationOk;
+  }
+
+  @Override
+  public void end(boolean interrupted) {
+    if (!interrupted && isStoppingPath()) {
+      output.accept(new ChassisSpeeds(), DriveFeedforwards.zeros(robotConfig.numModules));
+    }
+    PathPlannerLogging.logActivePath(null);
+    eventScheduler.end();
+  }
+
+  /**
+   * Whether the active path ends with the robot effectively stopped (vs. handing off velocity to a
+   * subsequent path). Matches the threshold used by {@link FollowPathCommand}.
+   */
+  private boolean isStoppingPath() {
+    return path.getGoalEndState().velocityMPS() < 0.1;
+  }
+
+  /**
+   * Project the robot's translation onto the path using the cached lookahead window. Falls back to
+   * a full-path scan if the window can't find a close-enough match (covers odometry resets or large
+   * disturbances).
+   */
+  private Projection projectOntoPath(Translation2d robotPos) {
+    List<PathPlannerTrajectoryState> states = trajectory.getStates();
+    int n = states.size();
+    if (n < 2) return new Projection(0, 0.0);
+
+    int windowStart = Math.max(0, lastProjectedIdx);
+    int windowEnd = Math.min(n - 2, lastProjectedIdx + LOOKAHEAD_SEGMENTS);
+    Projection best = scanWindow(robotPos, states, windowStart, windowEnd);
+
+    // If the best projection saturated to the forward edge of the window, scan one more window
+    // forward to handle fast moves that crossed multiple states in one tick.
+    if (best.segmentIndex == windowEnd && best.segmentU >= 0.99 && windowEnd < n - 2) {
+      int extEnd = Math.min(n - 2, windowEnd + LOOKAHEAD_SEGMENTS);
+      Projection extended = scanWindow(robotPos, states, windowEnd, extEnd);
+      if (extended.distance < best.distance) best = extended;
+    }
+
+    // Big-gap fallback: distance unreasonable, fall back to full scan.
+    if (best.distance > BIG_GAP_THRESHOLD_M) {
+      Projection fullScan = fullScan(robotPos);
+      // Only accept the full-scan result if it's strictly better and meaningfully forward of the
+      // window result (avoid jumping backward to a closer segment behind us).
+      if (fullScan.distance < best.distance && fullScan.arcLength >= lastProjectedS) {
+        best = fullScan;
+      }
+    }
+    return best;
+  }
+
+  private Projection fullScan(Translation2d robotPos) {
+    List<PathPlannerTrajectoryState> states = trajectory.getStates();
+    if (states.size() < 2) return new Projection(0, 0.0);
+    return scanWindow(robotPos, states, 0, states.size() - 2);
+  }
+
+  /**
+   * Closest-point-on-polyline over a segment range [startIdx, endIdx] (inclusive). For each segment
+   * (states[i], states[i+1]), compute the closest point on that line segment to robotPos via
+   * closed-form projection clamped to [0, 1]. Return the best (segmentIndex, segmentU, arcLength,
+   * distance). Package-private static so tests can exercise the real implementation.
+   */
+  static Projection scanWindow(
+      Translation2d robotPos, List<PathPlannerTrajectoryState> states, int startIdx, int endIdx) {
+    int bestIdx = startIdx;
+    double bestU = 0.0;
+    double bestDistSq = Double.POSITIVE_INFINITY;
+
+    for (int i = startIdx; i <= endIdx; i++) {
+      var a = states.get(i).pose.getTranslation();
+      var b = states.get(i + 1).pose.getTranslation();
+      double abx = b.getX() - a.getX();
+      double aby = b.getY() - a.getY();
+      double abLenSq = abx * abx + aby * aby;
+      double u;
+      if (abLenSq < 1e-12) {
+        u = 0.0;
+      } else {
+        double apx = robotPos.getX() - a.getX();
+        double apy = robotPos.getY() - a.getY();
+        u = (apx * abx + apy * aby) / abLenSq;
+        if (u < 0.0) u = 0.0;
+        else if (u > 1.0) u = 1.0;
+      }
+      double cx = a.getX() + u * abx;
+      double cy = a.getY() + u * aby;
+      double dx = robotPos.getX() - cx;
+      double dy = robotPos.getY() - cy;
+      double distSq = dx * dx + dy * dy;
+      if (distSq < bestDistSq) {
+        bestDistSq = distSq;
+        bestIdx = i;
+        bestU = u;
+      }
+    }
+
+    double sA = states.get(bestIdx).distanceAlongPath;
+    double sB = states.get(bestIdx + 1).distanceAlongPath;
+    double arcLength = sA + bestU * (sB - sA);
+    Projection out = new Projection(bestIdx, arcLength);
+    out.segmentU = bestU;
+    out.distance = Math.sqrt(bestDistSq);
+    return out;
+  }
+
+  private ChassisSpeeds speedsToFieldFrame() {
+    ChassisSpeeds robotSpeeds = speedsSupplier.get();
+    return ChassisSpeeds.fromRobotRelativeSpeeds(robotSpeeds, poseSupplier.get().getRotation());
+  }
+
+  /** Internal projection result. Package-private for testing. */
+  static class Projection {
+    final int segmentIndex;
+    final double arcLength;
+    double segmentU = 0.0;
+    double distance = 0.0;
+
+    Projection(int segmentIndex, double arcLength) {
+      this.segmentIndex = segmentIndex;
+      this.arcLength = arcLength;
+    }
+  }
+}

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/controllers/PPCrossTrackHolonomicController.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/controllers/PPCrossTrackHolonomicController.java
@@ -34,15 +34,9 @@ public class PPCrossTrackHolonomicController implements PathFollowingController 
   private final double curvatureFfGain;
   private final double period;
 
-  /**
-   * Tangent-direction rotation rate above which we treat the path's perpendicular frame as unstable
-   * and suppress the D-term and curvature feedforward for that cycle. The cross-track frame rotates
-   * with the tangent; when the rotation rate is high (cusps, U-turns, sharp corners), the D-term
-   * finite-difference picks up apparent error change driven purely by the rotating frame rather
-   * than real robot motion, and the curvature FF formula breaks down for the same reason. 5 rad/s
-   * is well above smooth-path tangent rates at typical FRC speeds (e.g. v=4 m/s on a 1 m radius
-   * curve gives 4 rad/s) but below path discontinuities (10+ rad/s).
-   */
+  // Above this tangent-rotation rate, suppress the cross-track D-term and curvature FF -- both
+  // would sense frame rotation as robot motion. Above smooth FRC paths (~4 rad/s at v=4 m/s on
+  // a 1 m radius), below cusp/discontinuity rates (10+ rad/s).
   private static final double TANGENT_RATE_THRESHOLD_RAD_PER_SEC = 5.0;
 
   private double lastCrossTrackError = 0.0;
@@ -133,7 +127,6 @@ public class PPCrossTrackHolonomicController implements PathFollowingController 
   @Override
   public ChassisSpeeds calculateRobotRelativeSpeeds(
       Pose2d currentPose, PathPlannerTrajectoryState targetState) {
-    // Tangent direction of travel along the path at the target sample.
     Rotation2d tangent = targetState.heading;
     double tx = tangent.getCos();
     double ty = tangent.getSin();
@@ -141,31 +134,23 @@ public class PPCrossTrackHolonomicController implements PathFollowingController 
     double nx = -ty;
     double ny = tx;
 
-    // Detect rapid tangent-direction rotation (cusps, U-turns, sharp corners). The cross-track
-    // measurement frame rotates with the tangent; at high rotation rates the perpendicular
-    // direction changes faster than the robot's actual motion, making the D-term sense apparent
-    // error change driven by the frame rather than by robot motion, and breaking the smooth-
-    // curve assumption of the curvature FF. Suppress both for any tick where the rate exceeds
-    // the threshold; resume next tick once the rate drops.
+    // Suppress D-term and curvature FF when the tangent frame rotates faster than the robot
+    // (cusps, U-turns, sharp corners) -- both would sense frame motion as robot motion.
     boolean tangentFlipped = false;
     if (lastTangentHeading != null) {
       double headingDelta =
           MathUtil.angleModulus(tangent.getRadians() - lastTangentHeading.getRadians());
-      double rateRadPerSec = headingDelta / period;
-      tangentFlipped = Math.abs(rateRadPerSec) > TANGENT_RATE_THRESHOLD_RAD_PER_SEC;
+      tangentFlipped = Math.abs(headingDelta / period) > TANGENT_RATE_THRESHOLD_RAD_PER_SEC;
     }
     lastTangentHeading = tangent;
 
-    // Decompose error vector (robot - target) into along-track and cross-track components.
-    // Along-track: positive if robot is AHEAD of target along the tangent. Cross-track: positive
-    // if robot is LEFT of the path tangent (in normal direction).
+    // Decompose (robot - target) into along-track (+ = ahead) and cross-track (+ = left of
+    // tangent).
     Translation2d delta = currentPose.getTranslation().minus(targetState.pose.getTranslation());
     double alongTrackError = delta.getX() * tx + delta.getY() * ty;
     double crossTrackError = delta.getX() * nx + delta.getY() * ny;
 
-    // Finite-difference rate for cross-track. Initialized to 0 on the first sample, and zeroed
-    // across a tangent discontinuity to avoid a spurious kick when the perpendicular frame
-    // rotates.
+    // Cross-track rate: finite-difference, zeroed on first sample and across tangent flips.
     double crossTrackRate;
     if (hasLastError && !tangentFlipped) {
       crossTrackRate = (crossTrackError - lastCrossTrackError) / period;
@@ -175,35 +160,25 @@ public class PPCrossTrackHolonomicController implements PathFollowingController 
     lastCrossTrackError = crossTrackError;
     hasLastError = true;
 
-    // Cross-track correction pulls the robot back toward the path (negate sign of error).
+    // Negate: pulls robot toward path.
     double crossTrackCorrection = -(crossTrackKp * crossTrackError + crossTrackKd * crossTrackRate);
 
-    // Along-track correction adds extra tangent-direction velocity when the robot lags the
-    // target sample. Without this, when the planned velocity profile decelerates faster than the
-    // robot can physically achieve (or the robot otherwise falls behind on the path), the
-    // velocity FF alone has no recovery mechanism -- target.fieldSpeeds points along the
-    // planned tangent direction at the planned magnitude, with no awareness of where the robot
-    // is. Adding -alongTrackKp * alongTrackError gives positive tangent velocity when robot is
-    // behind, negative when ahead.
+    // Along-track P gives a recovery term when the planned-v FF alone leaves the robot lagging.
     double alongTrackCorrection = -alongTrackKp * alongTrackError;
 
-    // Curvature FF anticipates centripetal drift: extra perpendicular velocity = gain * v^2 * kappa
-    // Suppressed across a tangent discontinuity since the curvature value there reflects the
-    // chord-discretization spike, not a continuous local curve.
+    // Centripetal FF: gain * v^2 * kappa. Suppressed across tangent discontinuities.
     double v = targetState.linearVelocity;
     double curvatureFf =
         tangentFlipped ? 0.0 : (curvatureFfGain * v * v * targetState.curvatureRadPerMeter);
 
     double perpVelocity = crossTrackCorrection + curvatureFf;
 
-    // Sum: planned velocity FF + along-track correction (along tangent) + perpendicular
-    // correction (along normal). All in field frame.
+    // Sum in field frame: planned FF + along-track (tangent) + perp (normal).
     double vxField =
         targetState.fieldSpeeds.vxMetersPerSecond + alongTrackCorrection * tx + perpVelocity * nx;
     double vyField =
         targetState.fieldSpeeds.vyMetersPerSecond + alongTrackCorrection * ty + perpVelocity * ny;
 
-    // Heading PID against target holonomic rotation, plus rotational FF from planned omega.
     double rotationFeedback =
         rotationController.calculate(
             currentPose.getRotation().getRadians(), targetState.pose.getRotation().getRadians());

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/controllers/PPCrossTrackHolonomicController.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/controllers/PPCrossTrackHolonomicController.java
@@ -1,0 +1,146 @@
+package com.pathplanner.lib.controllers;
+
+import com.pathplanner.lib.config.PIDConstants;
+import com.pathplanner.lib.trajectory.PathPlannerTrajectoryState;
+import edu.wpi.first.math.controller.PIDController;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.kinematics.ChassisSpeeds;
+
+/**
+ * Holonomic path-following controller that applies cross-track PD on the perpendicular-to-tangent
+ * error rather than per-axis PID, plus a curvature feedforward to anticipate centripetal drift on
+ * curves. The tangent-direction velocity comes from {@code targetState.fieldSpeeds} as a
+ * feedforward; rotation is closed-loop PID against the target holonomic rotation.
+ *
+ * <p>Designed to be paired with {@link com.pathplanner.lib.commands.FollowPathDistanceCommand},
+ * which samples the trajectory by arc length and feeds a projected target state to this controller.
+ *
+ * <p>Differences vs {@link PPHolonomicDriveController}:
+ *
+ * <ul>
+ *   <li>Cross-track (1D, perpendicular to path) PD instead of independent x/y PID, so the
+ *       controller doesn't fight the planned tangent-direction velocity
+ *   <li>Optional curvature feedforward to reduce steady-state lateral error on curves
+ * </ul>
+ */
+public class PPCrossTrackHolonomicController implements PathFollowingController {
+  private final double crossTrackKp;
+  private final double crossTrackKd;
+  private final PIDController rotationController;
+  private final double curvatureFfGain;
+  private final double period;
+
+  private double lastCrossTrackError = 0.0;
+  private boolean hasLastError = false;
+
+  /**
+   * Construct a cross-track holonomic controller with full configuration.
+   *
+   * @param crossTrackConstants PID constants for cross-track correction. Only kP and kD are used
+   *     (cross-track is 1D and reset every cycle, so kI/iZone are ignored).
+   * @param rotationConstants PID constants for the rotation controller. All fields used.
+   * @param curvatureFfGain Centripetal feedforward gain, in seconds. Applied as a
+   *     perpendicular-to-tangent velocity offset of magnitude {@code gain * v^2 * kappa} to counter
+   *     outward drift on curves. Set to 0 to disable.
+   * @param period Control-loop period in seconds.
+   */
+  public PPCrossTrackHolonomicController(
+      PIDConstants crossTrackConstants,
+      PIDConstants rotationConstants,
+      double curvatureFfGain,
+      double period) {
+    this.crossTrackKp = crossTrackConstants.kP;
+    this.crossTrackKd = crossTrackConstants.kD;
+    this.rotationController =
+        new PIDController(rotationConstants.kP, rotationConstants.kI, rotationConstants.kD, period);
+    this.rotationController.setIntegratorRange(-rotationConstants.iZone, rotationConstants.iZone);
+    this.rotationController.enableContinuousInput(-Math.PI, Math.PI);
+    this.curvatureFfGain = curvatureFfGain;
+    this.period = period;
+  }
+
+  /**
+   * Construct a cross-track holonomic controller with a default 20 ms period.
+   *
+   * @param crossTrackConstants Cross-track PD constants (kI/iZone ignored).
+   * @param rotationConstants Rotation PID constants.
+   * @param curvatureFfGain Curvature feedforward gain in seconds.
+   */
+  public PPCrossTrackHolonomicController(
+      PIDConstants crossTrackConstants, PIDConstants rotationConstants, double curvatureFfGain) {
+    this(crossTrackConstants, rotationConstants, curvatureFfGain, 0.02);
+  }
+
+  /**
+   * Construct a cross-track holonomic controller with the tuning values validated on the reference
+   * FRC swerve: crossTrackKp=3.0, crossTrackKd=0.5, rotationKp=5.0, curvatureFfGain=0.1.
+   *
+   * @return Controller with default tuning
+   */
+  public static PPCrossTrackHolonomicController defaults() {
+    return new PPCrossTrackHolonomicController(
+        new PIDConstants(3.0, 0.0, 0.5), new PIDConstants(5.0, 0.0, 0.0), 0.1);
+  }
+
+  @Override
+  public void reset(Pose2d currentPose, ChassisSpeeds currentSpeeds) {
+    rotationController.reset();
+    lastCrossTrackError = 0.0;
+    hasLastError = false;
+  }
+
+  @Override
+  public ChassisSpeeds calculateRobotRelativeSpeeds(
+      Pose2d currentPose, PathPlannerTrajectoryState targetState) {
+    // Tangent direction of travel along the path at the target sample.
+    Rotation2d tangent = targetState.heading;
+    double tx = tangent.getCos();
+    double ty = tangent.getSin();
+    // Left-perpendicular to tangent (90 deg CCW).
+    double nx = -ty;
+    double ny = tx;
+
+    // Signed cross-track error: positive if robot is left of the path tangent.
+    Translation2d delta = currentPose.getTranslation().minus(targetState.pose.getTranslation());
+    double crossTrackError = delta.getX() * nx + delta.getY() * ny;
+
+    // Finite-difference rate. Initialized to 0 on the first sample to avoid a spurious kick.
+    double crossTrackRate;
+    if (hasLastError) {
+      crossTrackRate = (crossTrackError - lastCrossTrackError) / period;
+    } else {
+      crossTrackRate = 0.0;
+    }
+    lastCrossTrackError = crossTrackError;
+    hasLastError = true;
+
+    // Cross-track correction pulls the robot back toward the path (so subtract the error).
+    double crossTrackCorrection = -(crossTrackKp * crossTrackError + crossTrackKd * crossTrackRate);
+
+    // Curvature FF anticipates centripetal drift: extra perpendicular velocity = gain * v^2 * kappa
+    double v = targetState.linearVelocity;
+    double curvatureFf = curvatureFfGain * v * v * targetState.curvatureRadPerMeter;
+
+    double perpVelocity = crossTrackCorrection + curvatureFf;
+
+    // Sum tangent FF velocity + perpendicular correction (field frame).
+    double vxField = targetState.fieldSpeeds.vxMetersPerSecond + perpVelocity * nx;
+    double vyField = targetState.fieldSpeeds.vyMetersPerSecond + perpVelocity * ny;
+
+    // Heading PID against target holonomic rotation, plus rotational FF from planned omega.
+    double rotationFeedback =
+        rotationController.calculate(
+            currentPose.getRotation().getRadians(), targetState.pose.getRotation().getRadians());
+    double omega = targetState.fieldSpeeds.omegaRadiansPerSecond + rotationFeedback;
+
+    return ChassisSpeeds.fromFieldRelativeSpeeds(
+        vxField, vyField, omega, currentPose.getRotation());
+  }
+
+  @Override
+  public boolean isHolonomic() {
+    return true;
+  }
+}

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/controllers/PPCrossTrackHolonomicController.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/controllers/PPCrossTrackHolonomicController.java
@@ -2,6 +2,7 @@ package com.pathplanner.lib.controllers;
 
 import com.pathplanner.lib.config.PIDConstants;
 import com.pathplanner.lib.trajectory.PathPlannerTrajectoryState;
+import edu.wpi.first.math.MathUtil;
 import edu.wpi.first.math.controller.PIDController;
 import edu.wpi.first.math.geometry.Pose2d;
 import edu.wpi.first.math.geometry.Rotation2d;
@@ -28,18 +29,34 @@ import edu.wpi.first.math.kinematics.ChassisSpeeds;
 public class PPCrossTrackHolonomicController implements PathFollowingController {
   private final double crossTrackKp;
   private final double crossTrackKd;
+  private final double alongTrackKp;
   private final PIDController rotationController;
   private final double curvatureFfGain;
   private final double period;
 
+  /**
+   * Tangent-direction rotation rate above which we treat the path's perpendicular frame as unstable
+   * and suppress the D-term and curvature feedforward for that cycle. The cross-track frame rotates
+   * with the tangent; when the rotation rate is high (cusps, U-turns, sharp corners), the D-term
+   * finite-difference picks up apparent error change driven purely by the rotating frame rather
+   * than real robot motion, and the curvature FF formula breaks down for the same reason. 5 rad/s
+   * is well above smooth-path tangent rates at typical FRC speeds (e.g. v=4 m/s on a 1 m radius
+   * curve gives 4 rad/s) but below path discontinuities (10+ rad/s).
+   */
+  private static final double TANGENT_RATE_THRESHOLD_RAD_PER_SEC = 5.0;
+
   private double lastCrossTrackError = 0.0;
   private boolean hasLastError = false;
+  private Rotation2d lastTangentHeading = null;
 
   /**
    * Construct a cross-track holonomic controller with full configuration.
    *
-   * @param crossTrackConstants PID constants for cross-track correction. Only kP and kD are used
-   *     (cross-track is 1D and reset every cycle, so kI/iZone are ignored).
+   * @param crossTrackConstants PID constants for cross-track (perpendicular-to-tangent) correction.
+   *     Only kP and kD are used (cross-track is 1D and reset every cycle, so kI/iZone are ignored).
+   * @param alongTrackKp Proportional gain for along-track (tangent-direction) correction. Adds
+   *     extra tangent-direction velocity proportional to tangent-direction lag, so the robot
+   *     catches up to the target sample when it falls behind. Set to 0 to disable.
    * @param rotationConstants PID constants for the rotation controller. All fields used.
    * @param curvatureFfGain Centripetal feedforward gain, in seconds. Applied as a
    *     perpendicular-to-tangent velocity offset of magnitude {@code gain * v^2 * kappa} to counter
@@ -48,11 +65,13 @@ public class PPCrossTrackHolonomicController implements PathFollowingController 
    */
   public PPCrossTrackHolonomicController(
       PIDConstants crossTrackConstants,
+      double alongTrackKp,
       PIDConstants rotationConstants,
       double curvatureFfGain,
       double period) {
     this.crossTrackKp = crossTrackConstants.kP;
     this.crossTrackKd = crossTrackConstants.kD;
+    this.alongTrackKp = alongTrackKp;
     this.rotationController =
         new PIDController(rotationConstants.kP, rotationConstants.kI, rotationConstants.kD, period);
     this.rotationController.setIntegratorRange(-rotationConstants.iZone, rotationConstants.iZone);
@@ -65,23 +84,42 @@ public class PPCrossTrackHolonomicController implements PathFollowingController 
    * Construct a cross-track holonomic controller with a default 20 ms period.
    *
    * @param crossTrackConstants Cross-track PD constants (kI/iZone ignored).
+   * @param alongTrackKp Along-track proportional gain (0 to disable).
    * @param rotationConstants Rotation PID constants.
    * @param curvatureFfGain Curvature feedforward gain in seconds.
    */
   public PPCrossTrackHolonomicController(
+      PIDConstants crossTrackConstants,
+      double alongTrackKp,
+      PIDConstants rotationConstants,
+      double curvatureFfGain) {
+    this(crossTrackConstants, alongTrackKp, rotationConstants, curvatureFfGain, 0.02);
+  }
+
+  /**
+   * Construct a cross-track holonomic controller without along-track correction. Use this if your
+   * path's velocity profile is reliable enough that tangent-direction tracking comes "for free"
+   * from the planned {@code targetState.fieldSpeeds} feedforward.
+   *
+   * @param crossTrackConstants Cross-track PD constants.
+   * @param rotationConstants Rotation PID constants.
+   * @param curvatureFfGain Curvature FF gain.
+   */
+  public PPCrossTrackHolonomicController(
       PIDConstants crossTrackConstants, PIDConstants rotationConstants, double curvatureFfGain) {
-    this(crossTrackConstants, rotationConstants, curvatureFfGain, 0.02);
+    this(crossTrackConstants, 0.0, rotationConstants, curvatureFfGain, 0.02);
   }
 
   /**
    * Construct a cross-track holonomic controller with the tuning values validated on the reference
-   * FRC swerve: crossTrackKp=3.0, crossTrackKd=0.5, rotationKp=5.0, curvatureFfGain=0.1.
+   * FRC swerve: crossTrackKp=3.0, crossTrackKd=0.5, alongTrackKp=2.0, rotationKp=5.0,
+   * curvatureFfGain=0.1.
    *
    * @return Controller with default tuning
    */
   public static PPCrossTrackHolonomicController defaults() {
     return new PPCrossTrackHolonomicController(
-        new PIDConstants(3.0, 0.0, 0.5), new PIDConstants(5.0, 0.0, 0.0), 0.1);
+        new PIDConstants(3.0, 0.0, 0.5), 2.0, new PIDConstants(5.0, 0.0, 0.0), 0.1);
   }
 
   @Override
@@ -89,6 +127,7 @@ public class PPCrossTrackHolonomicController implements PathFollowingController 
     rotationController.reset();
     lastCrossTrackError = 0.0;
     hasLastError = false;
+    lastTangentHeading = null;
   }
 
   @Override
@@ -102,13 +141,33 @@ public class PPCrossTrackHolonomicController implements PathFollowingController 
     double nx = -ty;
     double ny = tx;
 
-    // Signed cross-track error: positive if robot is left of the path tangent.
+    // Detect rapid tangent-direction rotation (cusps, U-turns, sharp corners). The cross-track
+    // measurement frame rotates with the tangent; at high rotation rates the perpendicular
+    // direction changes faster than the robot's actual motion, making the D-term sense apparent
+    // error change driven by the frame rather than by robot motion, and breaking the smooth-
+    // curve assumption of the curvature FF. Suppress both for any tick where the rate exceeds
+    // the threshold; resume next tick once the rate drops.
+    boolean tangentFlipped = false;
+    if (lastTangentHeading != null) {
+      double headingDelta =
+          MathUtil.angleModulus(tangent.getRadians() - lastTangentHeading.getRadians());
+      double rateRadPerSec = headingDelta / period;
+      tangentFlipped = Math.abs(rateRadPerSec) > TANGENT_RATE_THRESHOLD_RAD_PER_SEC;
+    }
+    lastTangentHeading = tangent;
+
+    // Decompose error vector (robot - target) into along-track and cross-track components.
+    // Along-track: positive if robot is AHEAD of target along the tangent. Cross-track: positive
+    // if robot is LEFT of the path tangent (in normal direction).
     Translation2d delta = currentPose.getTranslation().minus(targetState.pose.getTranslation());
+    double alongTrackError = delta.getX() * tx + delta.getY() * ty;
     double crossTrackError = delta.getX() * nx + delta.getY() * ny;
 
-    // Finite-difference rate. Initialized to 0 on the first sample to avoid a spurious kick.
+    // Finite-difference rate for cross-track. Initialized to 0 on the first sample, and zeroed
+    // across a tangent discontinuity to avoid a spurious kick when the perpendicular frame
+    // rotates.
     double crossTrackRate;
-    if (hasLastError) {
+    if (hasLastError && !tangentFlipped) {
       crossTrackRate = (crossTrackError - lastCrossTrackError) / period;
     } else {
       crossTrackRate = 0.0;
@@ -116,18 +175,33 @@ public class PPCrossTrackHolonomicController implements PathFollowingController 
     lastCrossTrackError = crossTrackError;
     hasLastError = true;
 
-    // Cross-track correction pulls the robot back toward the path (so subtract the error).
+    // Cross-track correction pulls the robot back toward the path (negate sign of error).
     double crossTrackCorrection = -(crossTrackKp * crossTrackError + crossTrackKd * crossTrackRate);
 
+    // Along-track correction adds extra tangent-direction velocity when the robot lags the
+    // target sample. Without this, when the planned velocity profile decelerates faster than the
+    // robot can physically achieve (or the robot otherwise falls behind on the path), the
+    // velocity FF alone has no recovery mechanism -- target.fieldSpeeds points along the
+    // planned tangent direction at the planned magnitude, with no awareness of where the robot
+    // is. Adding -alongTrackKp * alongTrackError gives positive tangent velocity when robot is
+    // behind, negative when ahead.
+    double alongTrackCorrection = -alongTrackKp * alongTrackError;
+
     // Curvature FF anticipates centripetal drift: extra perpendicular velocity = gain * v^2 * kappa
+    // Suppressed across a tangent discontinuity since the curvature value there reflects the
+    // chord-discretization spike, not a continuous local curve.
     double v = targetState.linearVelocity;
-    double curvatureFf = curvatureFfGain * v * v * targetState.curvatureRadPerMeter;
+    double curvatureFf =
+        tangentFlipped ? 0.0 : (curvatureFfGain * v * v * targetState.curvatureRadPerMeter);
 
     double perpVelocity = crossTrackCorrection + curvatureFf;
 
-    // Sum tangent FF velocity + perpendicular correction (field frame).
-    double vxField = targetState.fieldSpeeds.vxMetersPerSecond + perpVelocity * nx;
-    double vyField = targetState.fieldSpeeds.vyMetersPerSecond + perpVelocity * ny;
+    // Sum: planned velocity FF + along-track correction (along tangent) + perpendicular
+    // correction (along normal). All in field frame.
+    double vxField =
+        targetState.fieldSpeeds.vxMetersPerSecond + alongTrackCorrection * tx + perpVelocity * nx;
+    double vyField =
+        targetState.fieldSpeeds.vyMetersPerSecond + alongTrackCorrection * ty + perpVelocity * ny;
 
     // Heading PID against target holonomic rotation, plus rotational FF from planned omega.
     double rotationFeedback =

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/trajectory/PathPlannerTrajectory.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/trajectory/PathPlannerTrajectory.java
@@ -33,6 +33,23 @@ public class PathPlannerTrajectory {
   public PathPlannerTrajectory(List<PathPlannerTrajectoryState> states, List<Event> events) {
     this.states = states;
     this.events = events;
+    populateDistanceAlongPath(this.states);
+  }
+
+  /**
+   * Walk the state list and assign each state's cumulative arc length from the trajectory start by
+   * summing pose-to-pose distances. Always recomputes from poses, so calling twice on the same
+   * state list yields the same result. Used so that {@link #sampleByDistance(double)} works for any
+   * construction path, including Choreo trajectories that don't go through {@link #generateStates}.
+   */
+  private static void populateDistanceAlongPath(List<PathPlannerTrajectoryState> states) {
+    if (states.isEmpty()) return;
+    states.get(0).distanceAlongPath = 0.0;
+    for (int i = 1; i < states.size(); i++) {
+      double segment =
+          states.get(i).pose.getTranslation().getDistance(states.get(i - 1).pose.getTranslation());
+      states.get(i).distanceAlongPath = states.get(i - 1).distanceAlongPath + segment;
+    }
   }
 
   /**
@@ -212,6 +229,10 @@ public class PathPlannerTrajectory {
       // Create feedforwards for the end state
       states.get(states.size() - 1).feedforwards = DriveFeedforwards.zeros(config.numModules);
     }
+
+    // Populate cumulative arc length from pose positions. Works for both the Choreo branch
+    // (states come from the ideal-trajectory cache) and the generated branch.
+    populateDistanceAlongPath(this.states);
   }
 
   private static void generateStates(
@@ -712,6 +733,51 @@ public class PathPlannerTrajectory {
    */
   public PathPlannerTrajectoryState sample(Time time) {
     return sample(time.in(Seconds));
+  }
+
+  /**
+   * Get the total arc length of the trajectory in meters.
+   *
+   * @return Cumulative distance along the path from start to end
+   */
+  public double getTotalArcLength() {
+    return getEndState().distanceAlongPath;
+  }
+
+  /**
+   * Get the target state at the given arc length along the trajectory. Unlike {@link
+   * #sample(double)}, this samples by distance traveled rather than elapsed time, which is the
+   * natural parameterization for projection-based path following.
+   *
+   * @param distanceMeters Distance along the path to sample at, clamped to [0, totalArcLength]
+   * @return The target state
+   */
+  public PathPlannerTrajectoryState sampleByDistance(double distanceMeters) {
+    if (distanceMeters <= getInitialState().distanceAlongPath) return getInitialState();
+    if (distanceMeters >= getTotalArcLength()) return getEndState();
+
+    int low = 1;
+    int high = states.size() - 1;
+
+    while (low != high) {
+      int mid = (low + high) / 2;
+      if (getState(mid).distanceAlongPath < distanceMeters) {
+        low = mid + 1;
+      } else {
+        high = mid;
+      }
+    }
+
+    var sample = getState(low);
+    var prevSample = getState(low - 1);
+
+    double segmentLength = sample.distanceAlongPath - prevSample.distanceAlongPath;
+    if (segmentLength < 1e-6) {
+      return sample;
+    }
+
+    return prevSample.interpolate(
+        sample, (distanceMeters - prevSample.distanceAlongPath) / segmentLength);
   }
 
   /**

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/trajectory/PathPlannerTrajectory.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/trajectory/PathPlannerTrajectory.java
@@ -34,6 +34,7 @@ public class PathPlannerTrajectory {
     this.states = states;
     this.events = events;
     populateDistanceAlongPath(this.states);
+    populateCurvature(this.states);
   }
 
   /**
@@ -49,6 +50,35 @@ public class PathPlannerTrajectory {
       double segment =
           states.get(i).pose.getTranslation().getDistance(states.get(i - 1).pose.getTranslation());
       states.get(i).distanceAlongPath = states.get(i - 1).distanceAlongPath + segment;
+    }
+  }
+
+  /**
+   * Walk the state list and assign each state's signed path curvature in radians per meter (1/m),
+   * computed geometrically from the three adjacent state positions. Endpoints get zero. Sign
+   * convention matches {@link com.pathplanner.lib.util.GeometryUtil#calculateRadius}: positive
+   * curvature corresponds to a left turn. Works for any construction path, including Choreo
+   * trajectories.
+   */
+  private static void populateCurvature(List<PathPlannerTrajectoryState> states) {
+    int n = states.size();
+    if (n < 3) {
+      for (var s : states) s.curvatureRadPerMeter = 0.0;
+      return;
+    }
+    states.get(0).curvatureRadPerMeter = 0.0;
+    states.get(n - 1).curvatureRadPerMeter = 0.0;
+    for (int i = 1; i < n - 1; i++) {
+      double signedRadius =
+          GeometryUtil.calculateRadius(
+              states.get(i - 1).pose.getTranslation(),
+              states.get(i).pose.getTranslation(),
+              states.get(i + 1).pose.getTranslation());
+      if (!Double.isFinite(signedRadius) || Math.abs(signedRadius) < 1e-9) {
+        states.get(i).curvatureRadPerMeter = 0.0;
+      } else {
+        states.get(i).curvatureRadPerMeter = 1.0 / signedRadius;
+      }
     }
   }
 
@@ -233,6 +263,7 @@ public class PathPlannerTrajectory {
     // Populate cumulative arc length from pose positions. Works for both the Choreo branch
     // (states come from the ideal-trajectory cache) and the generated branch.
     populateDistanceAlongPath(this.states);
+    populateCurvature(this.states);
   }
 
   private static void generateStates(

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/trajectory/PathPlannerTrajectory.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/trajectory/PathPlannerTrajectory.java
@@ -289,12 +289,12 @@ public class PathPlannerTrajectory {
 
       // Holonomic rotation is interpolated. We use the distance along the path
       // to calculate how much to interpolate since the distribution of path points
-      // is not the same along the whole segment
-      double t =
-          (path.getPoint(i).distanceAlongPath
-                  - path.getPoint(prevRotationTargetIdx).distanceAlongPath)
-              / (path.getPoint(nextRotationTargetIdx).distanceAlongPath
-                  - path.getPoint(prevRotationTargetIdx).distanceAlongPath);
+      // is not the same along the whole segment. Guard the zero-length case (duplicate
+      // endpoints) to avoid a NaN rotation at the trajectory tail.
+      double prevDist = path.getPoint(prevRotationTargetIdx).distanceAlongPath;
+      double nextDist = path.getPoint(nextRotationTargetIdx).distanceAlongPath;
+      double denom = nextDist - prevDist;
+      double t = (denom > 1.0e-9) ? (path.getPoint(i).distanceAlongPath - prevDist) / denom : 1.0;
       Rotation2d holonomicRot = cosineInterpolate(prevRotationTargetRot, nextRotationTargetRot, t);
 
       Pose2d robotPose = new Pose2d(p.position, holonomicRot);

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/trajectory/PathPlannerTrajectoryState.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/trajectory/PathPlannerTrajectoryState.java
@@ -24,6 +24,11 @@ public class PathPlannerTrajectoryState implements Interpolatable<PathPlannerTra
   public Rotation2d heading = Rotation2d.kZero;
   /** The cumulative arc length traveled along the path to reach this state, in meters */
   public double distanceAlongPath = 0.0;
+  /**
+   * The signed path curvature at this state in radians per meter (1/m). Positive curves left,
+   * negative curves right. Used by curvature-feedforward path-following controllers.
+   */
+  public double curvatureRadPerMeter = 0.0;
 
   /** The feedforwards for each module */
   public DriveFeedforwards feedforwards;
@@ -68,34 +73,48 @@ public class PathPlannerTrajectoryState implements Interpolatable<PathPlannerTra
             MathUtil.interpolate(
                 fieldSpeeds.omegaRadiansPerSecond, endVal.fieldSpeeds.omegaRadiansPerSecond, t));
 
+    // heading is the chord direction (state[k] -> state[k+1]) and is constant along a segment.
+    // Integration below uses this start-state heading throughout, which keeps the integrated
+    // position on the chord rather than drifting toward the underlying curve. Callers reading
+    // targetState.heading see the current-segment chord direction, which is the correct
+    // tangent for perpendicular cross-track measurement.
     lerpedState.heading = heading;
     lerpedState.linearVelocity = MathUtil.interpolate(linearVelocity, endVal.linearVelocity, t);
     lerpedState.distanceAlongPath =
         MathUtil.interpolate(distanceAlongPath, endVal.distanceAlongPath, t);
+    lerpedState.curvatureRadPerMeter =
+        MathUtil.interpolate(curvatureRadPerMeter, endVal.curvatureRadPerMeter, t);
 
     // Integrate the field speeds to get the pose for this interpolated state, since linearly
-    // interpolating the pose gives an inaccurate result if the speeds are changing between states
+    // interpolating the pose gives an inaccurate result if the speeds are changing between
+    // states. Forward Euler with 10 ms steps, plus a remainder step for the last partial
+    // interval. Linear velocity is lerped per step; heading stays constant (the chord
+    // direction).
     double lerpedXPos = pose.getX();
     double lerpedYPos = pose.getY();
-    double intTime = timeSeconds + 0.01;
-    while (true) {
-      double intT = (intTime - timeSeconds) / (lerpedState.timeSeconds - timeSeconds);
-      double intLinearVel = MathUtil.interpolate(linearVelocity, lerpedState.linearVelocity, intT);
-      double intVX = intLinearVel * lerpedState.heading.getCos();
-      double intVY = intLinearVel * lerpedState.heading.getSin();
+    if (deltaT > 0) {
+      double cosH = heading.getCos();
+      double sinH = heading.getSin();
+      double intTime = timeSeconds;
+      while (true) {
+        double intT = (intTime - timeSeconds) / deltaT;
+        double intLinearVel = MathUtil.interpolate(linearVelocity, endVal.linearVelocity, intT);
+        double intVX = intLinearVel * cosH;
+        double intVY = intLinearVel * sinH;
 
-      if (intTime >= lerpedState.timeSeconds - 0.01) {
-        double dt = lerpedState.timeSeconds - intTime;
-        lerpedXPos += intVX * dt;
-        lerpedYPos += intVY * dt;
-        break;
+        double remainingTime = lerpedState.timeSeconds - intTime;
+        if (remainingTime <= 0.01) {
+          lerpedXPos += intVX * remainingTime;
+          lerpedYPos += intVY * remainingTime;
+          break;
+        }
+
+        lerpedXPos += intVX * 0.01;
+        lerpedYPos += intVY * 0.01;
+        intTime += 0.01;
       }
-
-      lerpedXPos += intVX * 0.01;
-      lerpedYPos += intVY * 0.01;
-
-      intTime += 0.01;
     }
+    // If deltaT == 0, pose stays at this.pose -- no integration needed, no divide-by-zero.
 
     lerpedState.pose =
         new Pose2d(
@@ -125,6 +144,8 @@ public class PathPlannerTrajectoryState implements Interpolatable<PathPlannerTra
     reversed.feedforwards = feedforwards.reverse();
     reversed.heading = heading.plus(Rotation2d.k180deg);
     reversed.distanceAlongPath = distanceAlongPath;
+    // Reversing direction of travel flips the sign of curvature (left becomes right).
+    reversed.curvatureRadPerMeter = -curvatureRadPerMeter;
 
     return reversed;
   }
@@ -144,6 +165,13 @@ public class PathPlannerTrajectoryState implements Interpolatable<PathPlannerTra
     flipped.feedforwards = feedforwards.flip();
     flipped.heading = FlippingUtil.flipFieldRotation(heading);
     flipped.distanceAlongPath = distanceAlongPath;
+    // Sign of signed curvature is preserved under 180-deg rotation (chirality preserved) but
+    // inverted under mirror reflection (chirality flipped).
+    flipped.curvatureRadPerMeter =
+        switch (FlippingUtil.symmetryType) {
+          case kMirrored -> -curvatureRadPerMeter;
+          case kRotational -> curvatureRadPerMeter;
+        };
 
     return flipped;
   }
@@ -163,6 +191,7 @@ public class PathPlannerTrajectoryState implements Interpolatable<PathPlannerTra
     copy.feedforwards = feedforwards;
     copy.heading = heading;
     copy.distanceAlongPath = distanceAlongPath;
+    copy.curvatureRadPerMeter = curvatureRadPerMeter;
     copy.deltaPos = deltaPos;
     copy.deltaRot = deltaRot;
     copy.moduleStates = moduleStates;

--- a/pathplannerlib/src/main/java/com/pathplanner/lib/trajectory/PathPlannerTrajectoryState.java
+++ b/pathplannerlib/src/main/java/com/pathplanner/lib/trajectory/PathPlannerTrajectoryState.java
@@ -22,6 +22,8 @@ public class PathPlannerTrajectoryState implements Interpolatable<PathPlannerTra
   public double linearVelocity = 0.0;
   /** The field-relative heading, or direction of travel, at this state */
   public Rotation2d heading = Rotation2d.kZero;
+  /** The cumulative arc length traveled along the path to reach this state, in meters */
+  public double distanceAlongPath = 0.0;
 
   /** The feedforwards for each module */
   public DriveFeedforwards feedforwards;
@@ -68,6 +70,8 @@ public class PathPlannerTrajectoryState implements Interpolatable<PathPlannerTra
 
     lerpedState.heading = heading;
     lerpedState.linearVelocity = MathUtil.interpolate(linearVelocity, endVal.linearVelocity, t);
+    lerpedState.distanceAlongPath =
+        MathUtil.interpolate(distanceAlongPath, endVal.distanceAlongPath, t);
 
     // Integrate the field speeds to get the pose for this interpolated state, since linearly
     // interpolating the pose gives an inaccurate result if the speeds are changing between states
@@ -120,6 +124,7 @@ public class PathPlannerTrajectoryState implements Interpolatable<PathPlannerTra
     reversed.linearVelocity = -linearVelocity;
     reversed.feedforwards = feedforwards.reverse();
     reversed.heading = heading.plus(Rotation2d.k180deg);
+    reversed.distanceAlongPath = distanceAlongPath;
 
     return reversed;
   }
@@ -138,6 +143,7 @@ public class PathPlannerTrajectoryState implements Interpolatable<PathPlannerTra
     flipped.fieldSpeeds = FlippingUtil.flipFieldSpeeds(fieldSpeeds);
     flipped.feedforwards = feedforwards.flip();
     flipped.heading = FlippingUtil.flipFieldRotation(heading);
+    flipped.distanceAlongPath = distanceAlongPath;
 
     return flipped;
   }
@@ -156,6 +162,7 @@ public class PathPlannerTrajectoryState implements Interpolatable<PathPlannerTra
     copy.linearVelocity = linearVelocity;
     copy.feedforwards = feedforwards;
     copy.heading = heading;
+    copy.distanceAlongPath = distanceAlongPath;
     copy.deltaPos = deltaPos;
     copy.deltaRot = deltaRot;
     copy.moduleStates = moduleStates;

--- a/pathplannerlib/src/test/java/com/pathplanner/lib/commands/FollowPathDistanceCommandTest.java
+++ b/pathplannerlib/src/test/java/com/pathplanner/lib/commands/FollowPathDistanceCommandTest.java
@@ -1,0 +1,148 @@
+package com.pathplanner.lib.commands;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.pathplanner.lib.trajectory.PathPlannerTrajectory;
+import com.pathplanner.lib.trajectory.PathPlannerTrajectoryState;
+import com.pathplanner.lib.util.DriveFeedforwards;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.kinematics.ChassisSpeeds;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+/**
+ * Tests focus on the projection geometry exercised by FollowPathDistanceCommand. The {@code
+ * projectOntoPath} / {@code scanWindow} machinery is exercised indirectly by constructing known
+ * trajectories and asserting that {@link PathPlannerTrajectory#sampleByDistance(double)} at the
+ * projected s lands where expected.
+ *
+ * <p>End-to-end command lifecycle (initialize/execute/end) needs a full RobotConfig and a real
+ * subsystem, so it's covered in sim/integration testing rather than unit tests.
+ */
+public class FollowPathDistanceCommandTest {
+
+  private static PathPlannerTrajectory straightLineX(double length) {
+    int samples = (int) Math.round(length / 0.05);
+    List<PathPlannerTrajectoryState> states = new ArrayList<>();
+    double step = length / samples;
+    for (int i = 0; i <= samples; i++) {
+      double x = i * step;
+      var s = new PathPlannerTrajectoryState();
+      s.timeSeconds = x / 1.0;
+      s.pose = new Pose2d(new Translation2d(x, 0), Rotation2d.kZero);
+      s.heading = Rotation2d.kZero;
+      s.linearVelocity = 1.0;
+      s.fieldSpeeds = new ChassisSpeeds(1.0, 0, 0);
+      s.feedforwards = DriveFeedforwards.zeros(4);
+      states.add(s);
+    }
+    return new PathPlannerTrajectory(states);
+  }
+
+  // Tests call the real FollowPathDistanceCommand.scanWindow (package-private static), so any
+  // future change to the algorithm is reflected here. End-to-end command lifecycle
+  // (initialize/execute/end) needs a full RobotConfig and a real subsystem, so it's covered in
+  // sim/integration testing rather than unit tests.
+
+  @Test
+  public void projectsExactlyOntoStraightPathAtKnownStates() {
+    var traj = straightLineX(2.0);
+    var states = traj.getStates();
+    for (int i = 0; i < states.size(); i++) {
+      var pos = states.get(i).pose.getTranslation();
+      var r = FollowPathDistanceCommand.scanWindow(pos, states, 0, states.size() - 2);
+      assertEquals(states.get(i).distanceAlongPath, r.arcLength, 1e-9, "state " + i);
+      assertEquals(0.0, r.distance, 1e-9);
+    }
+  }
+
+  @Test
+  public void projectsPerpendicularOffsetOntoNearestPathPoint() {
+    var traj = straightLineX(2.0);
+    var states = traj.getStates();
+    // Robot at (0.5, 0.3) on a path along +X: closest point is (0.5, 0), s=0.5, dist=0.3
+    var r =
+        FollowPathDistanceCommand.scanWindow(
+            new Translation2d(0.5, 0.3), states, 0, states.size() - 2);
+    assertEquals(0.5, r.arcLength, 1e-9);
+    assertEquals(0.3, r.distance, 1e-9);
+  }
+
+  @Test
+  public void projectsRobotAheadOfPathEndClampsToEndState() {
+    var traj = straightLineX(2.0);
+    var states = traj.getStates();
+    // Robot at (3.0, 0) -- past the path's end at (2.0, 0). The closest segment is the last,
+    // and u clamps to 1.0, giving s=totalArcLength.
+    var r =
+        FollowPathDistanceCommand.scanWindow(
+            new Translation2d(3.0, 0), states, 0, states.size() - 2);
+    assertEquals(traj.getTotalArcLength(), r.arcLength, 1e-9);
+  }
+
+  @Test
+  public void projectsRobotBehindPathStartClampsToInitialState() {
+    var traj = straightLineX(2.0);
+    var states = traj.getStates();
+    // Robot at (-1.0, 0) -- before path start. Best segment is the first, u clamps to 0.
+    var r =
+        FollowPathDistanceCommand.scanWindow(
+            new Translation2d(-1.0, 0), states, 0, states.size() - 2);
+    assertEquals(0.0, r.arcLength, 1e-9);
+  }
+
+  @Test
+  public void projectionWithinWindowDoesntCrossWholePath() {
+    var traj = straightLineX(2.0);
+    var states = traj.getStates();
+    // Lookahead window [5, 10]. Robot truly closest to state 20 at (1.0, 0) -- but window scan
+    // returns the best within [5, 10]. Demonstrates that the window limits results -- the full
+    // algorithm has a saturation-fallback (tested separately) to handle this.
+    var r = FollowPathDistanceCommand.scanWindow(new Translation2d(1.0, 0), states, 5, 10);
+    assertTrue(r.segmentIndex >= 5 && r.segmentIndex <= 10);
+    // The closest in-window point is the end of segment 10 (state 11 at s~=0.55).
+    assertTrue(r.arcLength <= 0.55 + 1e-6);
+  }
+
+  @Test
+  public void sampleByDistanceAtProjectedSGivesTargetPoseOnPath() {
+    var traj = straightLineX(2.0);
+    var states = traj.getStates();
+    // Robot at (1.234, 0.5) -- 1.234 along path, 0.5 m off. Sampling at projected s should
+    // return a state on the path at x=1.234 (sub-mm) on a straight constant-speed path.
+    var r =
+        FollowPathDistanceCommand.scanWindow(
+            new Translation2d(1.234, 0.5), states, 0, states.size() - 2);
+    var target = traj.sampleByDistance(r.arcLength);
+    assertEquals(1.234, target.pose.getX(), 1e-6);
+    assertEquals(0.0, target.pose.getY(), 1e-9);
+  }
+
+  @Test
+  public void endConditionsDefaultsHasSensibleValues() {
+    var ec = FollowPathDistanceCommand.EndConditions.defaults();
+    assertEquals(0.05, ec.distanceToleranceMeters(), 1e-9);
+    assertEquals(0.1, ec.velocityToleranceMPS(), 1e-9);
+    assertEquals(Math.toRadians(5.0), ec.rotationToleranceRad(), 1e-9);
+  }
+
+  @Test
+  public void endConditionsCustomValuesArePreserved() {
+    var ec = new FollowPathDistanceCommand.EndConditions(0.10, 0.2, Math.toRadians(10.0));
+    assertEquals(0.10, ec.distanceToleranceMeters(), 1e-9);
+    assertEquals(0.2, ec.velocityToleranceMPS(), 1e-9);
+    assertEquals(Math.toRadians(10.0), ec.rotationToleranceRad(), 1e-9);
+  }
+
+  @Test
+  public void endConditionsRotationCanBeDisabled() {
+    var ec = new FollowPathDistanceCommand.EndConditions(0.05, 0.1, Double.POSITIVE_INFINITY);
+    assertNotNull(ec);
+    assertEquals(Double.POSITIVE_INFINITY, ec.rotationToleranceRad());
+  }
+}

--- a/pathplannerlib/src/test/java/com/pathplanner/lib/controllers/PPCrossTrackHolonomicControllerTest.java
+++ b/pathplannerlib/src/test/java/com/pathplanner/lib/controllers/PPCrossTrackHolonomicControllerTest.java
@@ -145,6 +145,79 @@ public class PPCrossTrackHolonomicControllerTest {
   }
 
   @Test
+  public void alongTrackErrorProducesTangentDirectionCorrection() {
+    // With alongTrackKp > 0, robot BEHIND target along the tangent should get extra positive
+    // tangent-direction velocity to catch up.
+    var controller =
+        new PPCrossTrackHolonomicController(
+            new PIDConstants(0.0, 0.0, 0.0), 2.0, new PIDConstants(0.0, 0.0, 0.0), 0.0);
+    // Path going +X, target at (0.5, 0), robot at (0, 0). Robot is 0.5m behind along tangent.
+    var target = targetAt(0.5, 0.0, 0.0);
+    var pose = new Pose2d(new Translation2d(0.0, 0.0), Rotation2d.kZero);
+    var speeds = controller.calculateRobotRelativeSpeeds(pose, target);
+    // alongTrackError = (0 - 0.5) * 1 + 0 * 0 = -0.5  (robot behind = negative delta on +tangent)
+    // alongTrackCorrection = -2.0 * -0.5 = +1.0 m/s extra tangent velocity
+    // Tangent FF = 2.0 m/s. Total vx_field = 2.0 + 1.0 = 3.0.
+    assertEquals(3.0, speeds.vxMetersPerSecond, DELTA);
+    assertEquals(0.0, speeds.vyMetersPerSecond, DELTA);
+  }
+
+  @Test
+  public void alongTrackErrorAheadProducesNegativeCorrection() {
+    var controller =
+        new PPCrossTrackHolonomicController(
+            new PIDConstants(0.0, 0.0, 0.0), 2.0, new PIDConstants(0.0, 0.0, 0.0), 0.0);
+    // Robot 0.5m AHEAD along tangent. Should brake (negative correction).
+    var target = targetAt(0.0, 0.0, 0.0);
+    var pose = new Pose2d(new Translation2d(0.5, 0.0), Rotation2d.kZero);
+    var speeds = controller.calculateRobotRelativeSpeeds(pose, target);
+    // alongTrackError = +0.5, correction = -1.0. Tangent FF = 2.0. Total = 2.0 - 1.0 = 1.0.
+    assertEquals(1.0, speeds.vxMetersPerSecond, DELTA);
+  }
+
+  @Test
+  public void tangentFlipSuppressesDTermAndCurvatureFf() {
+    // Pure D + curvature FF, no P. If the controller weren't aware of tangent discontinuities,
+    // a 180-deg flip of targetState.heading between ticks would flip cross-track sign and
+    // produce a huge D-term spike. Verify the flip is detected and the spike suppressed.
+    var controller =
+        new PPCrossTrackHolonomicController(
+            new PIDConstants(0.0, 0.0, 1.0), new PIDConstants(0.0, 0.0, 0.0), 0.1);
+
+    // Tick 1: tangent points +X, robot 0.5m left of target. Establishes lastTangentHeading.
+    var target1 = targetAt(0.0, 0.0, 0.0);
+    target1.curvatureRadPerMeter = 10.0;
+    controller.calculateRobotRelativeSpeeds(
+        new Pose2d(new Translation2d(0, 0.5), Rotation2d.kZero), target1);
+
+    // Tick 2: same tangent, robot still off-path. D-term sees no rate change, output should be
+    // close to zero (just the small curvatureFf since target has nonzero kappa and v).
+    var t2Out =
+        controller.calculateRobotRelativeSpeeds(
+            new Pose2d(new Translation2d(0, 0.5), Rotation2d.kZero), target1);
+    double t2Mag = Math.hypot(t2Out.vxMetersPerSecond - 2.0, t2Out.vyMetersPerSecond);
+
+    // Tick 3: tangent flips 180 deg (cusp). curvature still high. If the controller doesn't
+    // suppress, D-term sees a huge sign flip and curvature FF produces a big perpendicular
+    // velocity, so the output magnitude jumps. With suppression, the output should stay
+    // similar to tick 2's magnitude (no kick).
+    var target2 = targetAt(0.0, 0.0, Math.PI);
+    target2.curvatureRadPerMeter = 10.0;
+    var t3Out =
+        controller.calculateRobotRelativeSpeeds(
+            new Pose2d(new Translation2d(0, 0.5), Rotation2d.kZero), target2);
+    double t3Mag = Math.hypot(t3Out.vxMetersPerSecond + 2.0, t3Out.vyMetersPerSecond);
+
+    // Without suppression, t3 would have a huge spike (10+ m/s perpendicular). With suppression,
+    // it should be near zero (no D-term, no curvature FF).
+    assertTrue(
+        t3Mag < 0.1,
+        "tangent-flip suppression failed: D+curvature kick should be suppressed (got "
+            + t3Mag
+            + ")");
+  }
+
+  @Test
   public void resetClearsCrossTrackDerivativeState() {
     // Pure D, period 0.02s: D output = (e_n - e_{n-1}) / 0.02, applied with sign such that vy
     // pushes back toward path (i.e. for rising +y error, vy goes -y).

--- a/pathplannerlib/src/test/java/com/pathplanner/lib/controllers/PPCrossTrackHolonomicControllerTest.java
+++ b/pathplannerlib/src/test/java/com/pathplanner/lib/controllers/PPCrossTrackHolonomicControllerTest.java
@@ -1,0 +1,186 @@
+package com.pathplanner.lib.controllers;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.pathplanner.lib.config.PIDConstants;
+import com.pathplanner.lib.trajectory.PathPlannerTrajectoryState;
+import com.pathplanner.lib.util.DriveFeedforwards;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.kinematics.ChassisSpeeds;
+import org.junit.jupiter.api.Test;
+
+public class PPCrossTrackHolonomicControllerTest {
+  private static final double DELTA = 1e-6;
+
+  private static PathPlannerTrajectoryState targetAt(double x, double y, double headingRad) {
+    var s = new PathPlannerTrajectoryState();
+    s.pose = new Pose2d(new Translation2d(x, y), Rotation2d.fromRadians(headingRad));
+    s.heading = Rotation2d.fromRadians(headingRad);
+    s.linearVelocity = 2.0;
+    s.fieldSpeeds = new ChassisSpeeds(2.0 * Math.cos(headingRad), 2.0 * Math.sin(headingRad), 0.0);
+    s.feedforwards = DriveFeedforwards.zeros(4);
+    return s;
+  }
+
+  @Test
+  public void zeroErrorReturnsFeedforwardOnly() {
+    var controller =
+        new PPCrossTrackHolonomicController(
+            new PIDConstants(3.0, 0.0, 0.5), new PIDConstants(5.0, 0.0, 0.0), 0.0);
+    var target = targetAt(1.0, 0.0, 0.0); // path going +X at (1,0)
+    var pose = new Pose2d(new Translation2d(1.0, 0.0), Rotation2d.kZero); // robot at target
+    var speeds = controller.calculateRobotRelativeSpeeds(pose, target);
+    // Robot-frame speeds when heading=0 == field speeds
+    assertEquals(2.0, speeds.vxMetersPerSecond, DELTA);
+    assertEquals(0.0, speeds.vyMetersPerSecond, DELTA);
+    assertEquals(0.0, speeds.omegaRadiansPerSecond, DELTA);
+  }
+
+  @Test
+  public void positiveCrossTrackErrorProducesPerpendicularCorrection() {
+    var controller =
+        new PPCrossTrackHolonomicController(
+            new PIDConstants(3.0, 0.0, 0.0), new PIDConstants(5.0, 0.0, 0.0), 0.0);
+    // Path going +X, target at origin, robot 0.1 m to the LEFT (+Y).
+    var target = targetAt(0.0, 0.0, 0.0);
+    var pose = new Pose2d(new Translation2d(0.0, 0.1), Rotation2d.kZero);
+    var speeds = controller.calculateRobotRelativeSpeeds(pose, target);
+    // Cross-track error should push robot back toward path (-Y direction).
+    // With kp=3.0, perpVelocity = -(3.0 * 0.1) = -0.3 m/s along the +Y direction.
+    // Plus tangent FF of 2.0 along +X.
+    assertEquals(2.0, speeds.vxMetersPerSecond, DELTA);
+    assertEquals(-0.3, speeds.vyMetersPerSecond, DELTA);
+  }
+
+  @Test
+  public void negativeCrossTrackErrorProducesPositivePerpendicularCorrection() {
+    var controller =
+        new PPCrossTrackHolonomicController(
+            new PIDConstants(3.0, 0.0, 0.0), new PIDConstants(5.0, 0.0, 0.0), 0.0);
+    // Path going +X, robot to the RIGHT (-Y).
+    var target = targetAt(0.0, 0.0, 0.0);
+    var pose = new Pose2d(new Translation2d(0.0, -0.1), Rotation2d.kZero);
+    var speeds = controller.calculateRobotRelativeSpeeds(pose, target);
+    assertEquals(2.0, speeds.vxMetersPerSecond, DELTA);
+    assertEquals(0.3, speeds.vyMetersPerSecond, DELTA);
+  }
+
+  @Test
+  public void tangentDirectionErrorProducesNoPerpendicularCorrection() {
+    var controller =
+        new PPCrossTrackHolonomicController(
+            new PIDConstants(3.0, 0.0, 0.0), new PIDConstants(5.0, 0.0, 0.0), 0.0);
+    // Path going +X, robot AHEAD of target along the tangent (no cross-track error).
+    var target = targetAt(0.0, 0.0, 0.0);
+    var pose = new Pose2d(new Translation2d(0.5, 0.0), Rotation2d.kZero);
+    var speeds = controller.calculateRobotRelativeSpeeds(pose, target);
+    // Tangent-direction error doesn't affect cross-track; output is pure feedforward.
+    assertEquals(2.0, speeds.vxMetersPerSecond, DELTA);
+    assertEquals(0.0, speeds.vyMetersPerSecond, DELTA);
+  }
+
+  @Test
+  public void curvatureFfAddsCentripetalPerpendicularVelocity() {
+    var controller =
+        new PPCrossTrackHolonomicController(
+            new PIDConstants(0.0, 0.0, 0.0), // disable cross-track to isolate FF
+            new PIDConstants(5.0, 0.0, 0.0),
+            0.1); // FF gain
+    // Target with left-curving path: kappa = +0.5 (1/m), v = 2.0 m/s
+    // curvatureFf = 0.1 * 2.0^2 * 0.5 = 0.2 m/s perpendicular (toward inside of curve, +Y).
+    var target = targetAt(0.0, 0.0, 0.0);
+    target.curvatureRadPerMeter = 0.5;
+    var pose = new Pose2d(new Translation2d(0.0, 0.0), Rotation2d.kZero);
+    var speeds = controller.calculateRobotRelativeSpeeds(pose, target);
+    assertEquals(2.0, speeds.vxMetersPerSecond, DELTA);
+    assertEquals(0.2, speeds.vyMetersPerSecond, DELTA);
+  }
+
+  @Test
+  public void curvatureFfSignFlipsForRightCurve() {
+    var controller =
+        new PPCrossTrackHolonomicController(
+            new PIDConstants(0.0, 0.0, 0.0), new PIDConstants(5.0, 0.0, 0.0), 0.1);
+    var target = targetAt(0.0, 0.0, 0.0);
+    target.curvatureRadPerMeter = -0.5; // right turn
+    var pose = new Pose2d(new Translation2d(0.0, 0.0), Rotation2d.kZero);
+    var speeds = controller.calculateRobotRelativeSpeeds(pose, target);
+    assertEquals(2.0, speeds.vxMetersPerSecond, DELTA);
+    assertEquals(-0.2, speeds.vyMetersPerSecond, DELTA);
+  }
+
+  @Test
+  public void headingErrorProducesRotationFeedback() {
+    var controller =
+        new PPCrossTrackHolonomicController(
+            new PIDConstants(0.0, 0.0, 0.0), new PIDConstants(5.0, 0.0, 0.0), 0.0);
+    var target = targetAt(0.0, 0.0, 0.0); // target rotation = 0
+    // Robot rotated 10 degrees right (-Z, negative): heading error pulls it back +Z.
+    var pose = new Pose2d(new Translation2d(0.0, 0.0), Rotation2d.fromDegrees(-10.0));
+    var speeds = controller.calculateRobotRelativeSpeeds(pose, target);
+    // kp=5.0, error = +10 deg = +0.1745 rad, expected omega = 5 * 0.1745 ~= 0.872 rad/s positive
+    assertTrue(speeds.omegaRadiansPerSecond > 0.5);
+    assertTrue(speeds.omegaRadiansPerSecond < 1.2);
+  }
+
+  @Test
+  public void defaultsFactoryProducesNonNullController() {
+    var c = PPCrossTrackHolonomicController.defaults();
+    var target = targetAt(0.0, 0.0, 0.0);
+    var pose = new Pose2d(new Translation2d(0.0, 0.1), Rotation2d.kZero);
+    var speeds = c.calculateRobotRelativeSpeeds(pose, target);
+    // Just confirm it produces *some* perpendicular correction with default gains
+    assertTrue(
+        speeds.vyMetersPerSecond < 0,
+        "default gains should pull robot back toward path (negative y for +y error)");
+  }
+
+  @Test
+  public void isHolonomicReturnsTrue() {
+    var c = PPCrossTrackHolonomicController.defaults();
+    assertTrue(c.isHolonomic());
+  }
+
+  @Test
+  public void resetClearsCrossTrackDerivativeState() {
+    // Pure D, period 0.02s: D output = (e_n - e_{n-1}) / 0.02, applied with sign such that vy
+    // pushes back toward path (i.e. for rising +y error, vy goes -y).
+    var controller =
+        new PPCrossTrackHolonomicController(
+            new PIDConstants(0.0, 0.0, 1.0), new PIDConstants(0.0, 0.0, 0.0), 0.0);
+    var target = targetAt(0.0, 0.0, 0.0);
+
+    // 1st call: hasLastError=false guard returns 0 regardless of error.
+    var first =
+        controller.calculateRobotRelativeSpeeds(
+            new Pose2d(new Translation2d(0, 0.0), Rotation2d.kZero), target);
+    assertEquals(0.0, first.vyMetersPerSecond, DELTA);
+
+    // 2nd call: error jumps from 0.0 to 0.2 over one period (0.02s). D term observes the
+    // change: rate = (0.2 - 0.0) / 0.02 = 10.0, correction = -kd * rate = -10 in the +y normal
+    // direction, so vy = -10.
+    var second =
+        controller.calculateRobotRelativeSpeeds(
+            new Pose2d(new Translation2d(0, 0.2), Rotation2d.kZero), target);
+    assertEquals(
+        -10.0,
+        second.vyMetersPerSecond,
+        1e-6,
+        "second call should see D-term reflecting the 0.0->0.2 step");
+
+    // Reset clears the error history. The next call with err=0.2 is again the "first call":
+    // hasLastError=false guard returns D=0, NOT -10 (which would indicate stale state).
+    controller.reset(Pose2d.kZero, new ChassisSpeeds());
+    var afterReset =
+        controller.calculateRobotRelativeSpeeds(
+            new Pose2d(new Translation2d(0, 0.2), Rotation2d.kZero), target);
+    assertEquals(
+        0.0,
+        afterReset.vyMetersPerSecond,
+        DELTA,
+        "after reset, first call must suppress D regardless of error magnitude");
+  }
+}

--- a/pathplannerlib/src/test/java/com/pathplanner/lib/trajectory/PathPlannerTrajectoryTest.java
+++ b/pathplannerlib/src/test/java/com/pathplanner/lib/trajectory/PathPlannerTrajectoryTest.java
@@ -1,0 +1,222 @@
+package com.pathplanner.lib.trajectory;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+import com.pathplanner.lib.util.DriveFeedforwards;
+import edu.wpi.first.math.geometry.Pose2d;
+import edu.wpi.first.math.geometry.Rotation2d;
+import edu.wpi.first.math.geometry.Translation2d;
+import edu.wpi.first.math.kinematics.ChassisSpeeds;
+import java.util.ArrayList;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+public class PathPlannerTrajectoryTest {
+  private static final double DELTA = 1e-6;
+
+  /**
+   * Build a synthetic trajectory along a quarter-circle of radius R from (R, 0) heading +Y to (0,
+   * R) heading -X. Samples are uniform in path-parameter theta. Timestamps are derived from the
+   * chord-summed arc length so time and distance are proportional (allowing time-vs-distance
+   * sampling comparisons on this curved path).
+   */
+  private static PathPlannerTrajectory quarterArc(double radius, double linearVel) {
+    double arcLength = radius * Math.PI / 2.0;
+    int samples = (int) Math.round(arcLength / 0.05);
+    List<PathPlannerTrajectoryState> states = new ArrayList<>();
+    double cumChord = 0.0;
+    double prevX = radius;
+    double prevY = 0.0;
+    for (int i = 0; i <= samples; i++) {
+      double theta = (Math.PI / 2.0) * (i / (double) samples);
+      double x = radius * Math.cos(theta);
+      double y = radius * Math.sin(theta);
+      if (i > 0) cumChord += Math.hypot(x - prevX, y - prevY);
+      Rotation2d heading = Rotation2d.fromRadians(theta + Math.PI / 2.0);
+      var s = new PathPlannerTrajectoryState();
+      s.timeSeconds = cumChord / linearVel;
+      s.pose = new Pose2d(x, y, Rotation2d.kZero);
+      s.linearVelocity = linearVel;
+      s.heading = heading;
+      s.fieldSpeeds =
+          new ChassisSpeeds(linearVel * heading.getCos(), linearVel * heading.getSin(), 0.0);
+      s.feedforwards = DriveFeedforwards.zeros(4);
+      states.add(s);
+      prevX = x;
+      prevY = y;
+    }
+    return new PathPlannerTrajectory(states);
+  }
+
+  /** Build a synthetic straight-line trajectory from origin along +X at constant speed. */
+  private static PathPlannerTrajectory straightLine(double length, double linearVel) {
+    int samples = (int) Math.round(length / 0.05);
+    List<PathPlannerTrajectoryState> states = new ArrayList<>();
+    double step = length / samples;
+    for (int i = 0; i <= samples; i++) {
+      double x = i * step;
+      var s = new PathPlannerTrajectoryState();
+      s.timeSeconds = x / linearVel;
+      s.pose = new Pose2d(x, 0, Rotation2d.kZero);
+      s.linearVelocity = linearVel;
+      s.heading = Rotation2d.kZero;
+      s.fieldSpeeds = new ChassisSpeeds(linearVel, 0, 0);
+      s.feedforwards = DriveFeedforwards.zeros(4);
+      states.add(s);
+    }
+    return new PathPlannerTrajectory(states);
+  }
+
+  @Test
+  public void populatesDistanceAlongPathCumulatively() {
+    var traj = quarterArc(1.0, 1.0);
+    assertEquals(0.0, traj.getInitialState().distanceAlongPath, DELTA);
+    // Each consecutive chord on the unit quarter-circle is < 0.05 m (chord < arc); confirm
+    // monotonic increase and last state matches sum of all segments.
+    double expected = 0.0;
+    var states = traj.getStates();
+    for (int i = 1; i < states.size(); i++) {
+      double seg =
+          states.get(i).pose.getTranslation().getDistance(states.get(i - 1).pose.getTranslation());
+      expected += seg;
+      assertEquals(expected, states.get(i).distanceAlongPath, DELTA);
+      assertTrue(states.get(i).distanceAlongPath > states.get(i - 1).distanceAlongPath);
+    }
+    assertEquals(expected, traj.getTotalArcLength(), DELTA);
+  }
+
+  @Test
+  public void getTotalArcLengthApproachesGeometricArcAsSamplingDensityIncreases() {
+    // Chord-summed length under-estimates the true arc length. For the quarter-circle of
+    // radius 1, the geometric arc is pi/2 ~= 1.5708. With ~31 samples (0.05 m spacing on a
+    // ~1.57 m arc), the chord sum should be within 0.1% of the true arc.
+    var traj = quarterArc(1.0, 1.0);
+    double geometricArc = Math.PI / 2.0;
+    assertEquals(geometricArc, traj.getTotalArcLength(), 1e-3);
+  }
+
+  @Test
+  public void sampleByDistanceClampsBelowZero() {
+    var traj = quarterArc(1.0, 1.0);
+    assertSame(traj.getInitialState(), traj.sampleByDistance(-1.0));
+    assertSame(traj.getInitialState(), traj.sampleByDistance(0.0));
+  }
+
+  @Test
+  public void sampleByDistanceClampsAboveEnd() {
+    var traj = quarterArc(1.0, 1.0);
+    double total = traj.getTotalArcLength();
+    assertSame(traj.getEndState(), traj.sampleByDistance(total));
+    assertSame(traj.getEndState(), traj.sampleByDistance(total + 1.0));
+  }
+
+  @Test
+  public void sampleByDistanceReturnsDistanceAlongPathExactly() {
+    // The interpolated distanceAlongPath field is a pure lerp of the bracket values, so it
+    // can be asserted exactly. (Pose values go through PathPlannerTrajectoryState.interpolate
+    // which Euler-integrates and inherits an existing upstream quirk where the loop starts
+    // at timeSeconds + 0.01; that's tested via the agreement-with-sample(time) tests below
+    // rather than absolute pose round-tripping.)
+    var traj = quarterArc(1.0, 1.0);
+    for (var state : traj.getStates()) {
+      var sampled = traj.sampleByDistance(state.distanceAlongPath);
+      assertEquals(state.distanceAlongPath, sampled.distanceAlongPath, 1e-9);
+    }
+  }
+
+  @Test
+  public void sampleByDistanceInterpolatesBetweenStates() {
+    // Halfway between two adjacent states should land near (not at) either endpoint, and on
+    // a quarter-circle, near the midpoint chord.
+    var traj = quarterArc(1.0, 1.0);
+    var states = traj.getStates();
+    var a = states.get(5);
+    var b = states.get(6);
+    double midS = (a.distanceAlongPath + b.distanceAlongPath) / 2.0;
+    var mid = traj.sampleByDistance(midS);
+    // distanceAlongPath itself is lerped exactly
+    assertEquals(midS, mid.distanceAlongPath, DELTA);
+    // Sampled pose should sit strictly between the bracket poses (not equal to either)
+    double dxA = mid.pose.getX() - a.pose.getX();
+    double dxB = b.pose.getX() - mid.pose.getX();
+    assertTrue(
+        Math.signum(dxA) == Math.signum(dxB) || dxA == 0 || dxB == 0,
+        "midpoint should advance monotonically between bracket states");
+  }
+
+  @Test
+  public void sampleByDistanceAgreesWithSampleByTimeOnStraightLine() {
+    // On a constant-speed straight line, t and s are exactly proportional; sample(t) and
+    // sampleByDistance(v*t) must produce identical poses.
+    double v = 1.5;
+    var traj = straightLine(2.0, v);
+    double totalT = traj.getTotalTimeSeconds();
+    for (double t = 0; t <= totalT; t += 0.07) {
+      var byTime = traj.sample(t);
+      var byDist = traj.sampleByDistance(v * t);
+      assertEquals(byTime.pose.getX(), byDist.pose.getX(), 1e-9, "pose-X mismatch at t=" + t);
+      assertEquals(byTime.pose.getY(), byDist.pose.getY(), 1e-9, "pose-Y mismatch at t=" + t);
+    }
+  }
+
+  @Test
+  public void sampleByDistanceAgreesWithSampleByTimeOnArc() {
+    // On the quarter-arc (timestamps derived from cumulative chord length so t and s are
+    // proportional at every state), the two samplers should agree within sub-mm at any query.
+    double v = 1.0;
+    var traj = quarterArc(1.0, v);
+    double totalT = traj.getTotalTimeSeconds();
+    for (double t = 0; t <= totalT; t += 0.05) {
+      var byTime = traj.sample(t);
+      var byDist = traj.sampleByDistance(v * t);
+      assertEquals(byTime.pose.getX(), byDist.pose.getX(), 1e-3, "pose-X mismatch at t=" + t);
+      assertEquals(byTime.pose.getY(), byDist.pose.getY(), 1e-3, "pose-Y mismatch at t=" + t);
+    }
+  }
+
+  @Test
+  public void distanceAlongPathSurvivesFlip() {
+    var traj = quarterArc(1.0, 1.0);
+    double totalBefore = traj.getTotalArcLength();
+    var flipped = traj.flip();
+    // flipped() rebuilds states via the (states, events) constructor which re-populates
+    // distanceAlongPath from pose distances. After flipping (rotate 180 + translate to mirror
+    // field), pose-to-pose distances are preserved, so total arc length must match.
+    assertEquals(totalBefore, flipped.getTotalArcLength(), DELTA);
+  }
+
+  @Test
+  public void copyWithTimePreservesDistanceAlongPath() {
+    var traj = quarterArc(1.0, 1.0);
+    var state = traj.getState(5);
+    var copy = state.copyWithTime(42.0);
+    assertEquals(state.distanceAlongPath, copy.distanceAlongPath, DELTA);
+    assertEquals(42.0, copy.timeSeconds, DELTA);
+  }
+
+  @Test
+  public void interpolatePreservesDistanceAlongPathLinearly() {
+    var s0 = new PathPlannerTrajectoryState();
+    s0.timeSeconds = 0;
+    s0.pose = Pose2d.kZero;
+    s0.heading = Rotation2d.kZero;
+    s0.linearVelocity = 1.0;
+    s0.fieldSpeeds = new ChassisSpeeds(1.0, 0, 0);
+    s0.feedforwards = DriveFeedforwards.zeros(4);
+    s0.distanceAlongPath = 0.0;
+
+    var s1 = new PathPlannerTrajectoryState();
+    s1.timeSeconds = 1.0;
+    s1.pose = new Pose2d(new Translation2d(1.0, 0), Rotation2d.kZero);
+    s1.heading = Rotation2d.kZero;
+    s1.linearVelocity = 1.0;
+    s1.fieldSpeeds = new ChassisSpeeds(1.0, 0, 0);
+    s1.feedforwards = DriveFeedforwards.zeros(4);
+    s1.distanceAlongPath = 1.0;
+
+    var mid = s0.interpolate(s1, 0.5);
+    assertEquals(0.5, mid.distanceAlongPath, DELTA);
+  }
+}

--- a/pathplannerlib/src/test/java/com/pathplanner/lib/trajectory/PathPlannerTrajectoryTest.java
+++ b/pathplannerlib/src/test/java/com/pathplanner/lib/trajectory/PathPlannerTrajectoryTest.java
@@ -114,16 +114,98 @@ public class PathPlannerTrajectoryTest {
 
   @Test
   public void sampleByDistanceReturnsDistanceAlongPathExactly() {
-    // The interpolated distanceAlongPath field is a pure lerp of the bracket values, so it
-    // can be asserted exactly. (Pose values go through PathPlannerTrajectoryState.interpolate
-    // which Euler-integrates and inherits an existing upstream quirk where the loop starts
-    // at timeSeconds + 0.01; that's tested via the agreement-with-sample(time) tests below
-    // rather than absolute pose round-tripping.)
+    // distanceAlongPath is a pure lerp of the bracket values.
     var traj = quarterArc(1.0, 1.0);
     for (var state : traj.getStates()) {
       var sampled = traj.sampleByDistance(state.distanceAlongPath);
       assertEquals(state.distanceAlongPath, sampled.distanceAlongPath, 1e-9);
     }
+  }
+
+  @Test
+  public void interpolateAtT1ReturnsEndPose() {
+    // Regression: pre-fix interpolate's loop started at timeSeconds + 0.01 and used the start
+    // state's heading throughout, so even at t=1 the pose was 1 0.01 s step short of endVal.
+    // With the fix, interpolate(s0, s1, 1.0) should reproduce s1.pose to sub-mm.
+    var traj = straightLine(2.0, 1.0);
+    var states = traj.getStates();
+    var a = states.get(10);
+    var b = states.get(11);
+    var lerped = a.interpolate(b, 1.0);
+    assertEquals(b.pose.getX(), lerped.pose.getX(), 1e-9);
+    assertEquals(b.pose.getY(), lerped.pose.getY(), 1e-9);
+  }
+
+  @Test
+  public void interpolateAtT0ReturnsStartPose() {
+    var traj = straightLine(2.0, 1.0);
+    var states = traj.getStates();
+    var a = states.get(10);
+    var b = states.get(11);
+    var lerped = a.interpolate(b, 0.0);
+    assertEquals(a.pose.getX(), lerped.pose.getX(), 1e-9);
+    assertEquals(a.pose.getY(), lerped.pose.getY(), 1e-9);
+  }
+
+  @Test
+  public void interpolateAtMidpointGivesGeometricMidpointOnStraightLine() {
+    var traj = straightLine(2.0, 1.0);
+    var states = traj.getStates();
+    var a = states.get(10); // x = 0.5
+    var b = states.get(11); // x = 0.55
+    var mid = a.interpolate(b, 0.5);
+    assertEquals(0.525, mid.pose.getX(), 1e-9);
+    assertEquals(0.0, mid.pose.getY(), 1e-9);
+  }
+
+  @Test
+  public void interpolateWithZeroDeltaTReturnsCopyOfStart() {
+    // Regression: pre-fix code divided by zero in intT = (intTime - timeSeconds) / deltaT,
+    // producing NaN pose. With the fix the integration is skipped when deltaT == 0.
+    var s0 = new PathPlannerTrajectoryState();
+    s0.timeSeconds = 1.0;
+    s0.pose = new Pose2d(new Translation2d(3.0, 4.0), Rotation2d.kZero);
+    s0.heading = Rotation2d.kZero;
+    s0.linearVelocity = 2.0;
+    s0.fieldSpeeds = new ChassisSpeeds(2.0, 0, 0);
+    s0.feedforwards = DriveFeedforwards.zeros(4);
+    var s1 = new PathPlannerTrajectoryState();
+    s1.timeSeconds = 1.0; // same time as s0
+    s1.pose = new Pose2d(new Translation2d(3.5, 4.0), Rotation2d.kZero);
+    s1.heading = Rotation2d.kZero;
+    s1.linearVelocity = 2.0;
+    s1.fieldSpeeds = new ChassisSpeeds(2.0, 0, 0);
+    s1.feedforwards = DriveFeedforwards.zeros(4);
+    var lerped = s0.interpolate(s1, 0.5);
+    assertTrue(Double.isFinite(lerped.pose.getX()), "deltaT=0 must not produce NaN");
+    assertTrue(Double.isFinite(lerped.pose.getY()), "deltaT=0 must not produce NaN");
+    assertEquals(s0.pose.getX(), lerped.pose.getX(), 1e-9);
+    assertEquals(s0.pose.getY(), lerped.pose.getY(), 1e-9);
+  }
+
+  @Test
+  public void interpolateWithSmallDeltaTIntegratesForward() {
+    // Regression: pre-fix code with deltaT < 0.01 entered the break case immediately with
+    // dt = lerpedState.timeSeconds - intTime = NEGATIVE, integrating BACKWARDS. With the fix,
+    // deltaT = 0.005 integrates v * 0.005 = 0.005 of forward motion.
+    var s0 = new PathPlannerTrajectoryState();
+    s0.timeSeconds = 0.0;
+    s0.pose = new Pose2d(new Translation2d(0.0, 0.0), Rotation2d.kZero);
+    s0.heading = Rotation2d.kZero;
+    s0.linearVelocity = 1.0;
+    s0.fieldSpeeds = new ChassisSpeeds(1.0, 0, 0);
+    s0.feedforwards = DriveFeedforwards.zeros(4);
+    var s1 = new PathPlannerTrajectoryState();
+    s1.timeSeconds = 0.005;
+    s1.pose = new Pose2d(new Translation2d(0.005, 0.0), Rotation2d.kZero);
+    s1.heading = Rotation2d.kZero;
+    s1.linearVelocity = 1.0;
+    s1.fieldSpeeds = new ChassisSpeeds(1.0, 0, 0);
+    s1.feedforwards = DriveFeedforwards.zeros(4);
+    var lerped = s0.interpolate(s1, 1.0);
+    // Forward motion expected: 1.0 m/s * 0.005 s = 0.005 m
+    assertEquals(0.005, lerped.pose.getX(), 1e-9);
+    assertEquals(0.0, lerped.pose.getY(), 1e-9);
   }
 
   @Test
@@ -194,6 +276,62 @@ public class PathPlannerTrajectoryTest {
     var copy = state.copyWithTime(42.0);
     assertEquals(state.distanceAlongPath, copy.distanceAlongPath, DELTA);
     assertEquals(42.0, copy.timeSeconds, DELTA);
+  }
+
+  @Test
+  public void curvaturePopulatedOnStraightLineIsZero() {
+    var traj = straightLine(2.0, 1.0);
+    for (var state : traj.getStates()) {
+      assertEquals(0.0, state.curvatureRadPerMeter, 1e-9);
+    }
+  }
+
+  @Test
+  public void curvaturePopulatedOnQuarterArcMatchesReciprocalRadius() {
+    // Unit circle -> kappa = 1.0 (1/m). Positive sign because the arc goes CCW (left turn).
+    var traj = quarterArc(1.0, 1.0);
+    // Interior states (skip endpoints which get 0).
+    var states = traj.getStates();
+    for (int i = 1; i < states.size() - 1; i++) {
+      // Allow some tolerance because three-point circle fit on a sampled arc has small error.
+      assertEquals(
+          1.0, states.get(i).curvatureRadPerMeter, 0.05, "expected curvature ~1.0 at state " + i);
+      assertTrue(
+          states.get(i).curvatureRadPerMeter > 0,
+          "left-turning arc should have positive curvature at state " + i);
+    }
+  }
+
+  @Test
+  public void curvatureEndpointsAreZero() {
+    var traj = quarterArc(1.0, 1.0);
+    var states = traj.getStates();
+    assertEquals(0.0, states.get(0).curvatureRadPerMeter, 1e-9);
+    assertEquals(0.0, states.get(states.size() - 1).curvatureRadPerMeter, 1e-9);
+  }
+
+  @Test
+  public void interpolatePreservesCurvatureLinearly() {
+    var s0 = new PathPlannerTrajectoryState();
+    s0.timeSeconds = 0;
+    s0.pose = Pose2d.kZero;
+    s0.heading = Rotation2d.kZero;
+    s0.linearVelocity = 1.0;
+    s0.fieldSpeeds = new ChassisSpeeds(1.0, 0, 0);
+    s0.feedforwards = DriveFeedforwards.zeros(4);
+    s0.curvatureRadPerMeter = 0.0;
+
+    var s1 = new PathPlannerTrajectoryState();
+    s1.timeSeconds = 1.0;
+    s1.pose = new Pose2d(new Translation2d(1.0, 0), Rotation2d.kZero);
+    s1.heading = Rotation2d.kZero;
+    s1.linearVelocity = 1.0;
+    s1.fieldSpeeds = new ChassisSpeeds(1.0, 0, 0);
+    s1.feedforwards = DriveFeedforwards.zeros(4);
+    s1.curvatureRadPerMeter = 2.0;
+
+    var mid = s0.interpolate(s1, 0.5);
+    assertEquals(1.0, mid.curvatureRadPerMeter, DELTA);
   }
 
   @Test


### PR DESCRIPTION
## Summary
Third and final PR in the distance-based path-following stack. **Depends on #1169 and #1170** -- until those merge, this PR's diff includes their changes too.

Adds four overloads of \`AutoBuilder.configureDistanceBased(...)\` that mirror the existing time-based \`configure(...)\` parameter shape:

| Overload | output type | endConditions |
|---|---|---|
| 1 (full) | \`BiConsumer<ChassisSpeeds, DriveFeedforwards>\` | explicit |
| 2 | \`BiConsumer<...>\` | uses \`EndConditions.defaults()\` |
| 3 | \`Consumer<ChassisSpeeds>\` | explicit |
| 4 | \`Consumer<ChassisSpeeds>\` | uses \`EndConditions.defaults()\` |

Sets the same \`globals\` fields as \`configure(...)\` and builds a \`pathFollowingCommandBuilder\` that creates \`FollowPathDistanceCommand\`. Explicitly leaves \`pathfindingConfigured = false\` since \`PathfindingCommand\` is intrinsically time-based; integrating distance-based pathfinding is a separate concern.

## Why
First-class API parity with \`configure(...)\` so users can opt into distance-based mode with one call instead of wiring \`configureCustom\` themselves.

## Tests
None added. PathPlannerLib has zero existing \`AutoBuilder\` unit tests because \`RobotConfig\`'s static initializer transitively loads WPILib NetworkTables JNI, which isn't available in pure-Java test scope. Following the same convention; verified via compile + \`spotlessJavaCheck\`.

\`followPath(PathPlannerPath)\` and the rest of the public \`AutoBuilder\` surface work transparently with distance-based mode -- they all delegate to the \`pathFollowingCommandBuilder\` lambda which now produces \`FollowPathDistanceCommand\`. The \`pathfindToPose\` / \`pathfindThenFollowPath\` family correctly throws when used in distance-based mode (the standard not-configured error).

## Test plan
- [x] Existing 43 tests pass
- [x] \`spotlessJavaCheck\` clean
- [ ] End-to-end smoke test in a real robot project (in progress)