### PR TITLE
Add settings keyboard shortcut

### DIFF
--- a/Writerside/topics/gui-Controls-and-Shortcuts.md
+++ b/Writerside/topics/gui-Controls-and-Shortcuts.md
@@ -5,6 +5,7 @@
 <tr><td>Double-Click on Field</td><td>Add Waypoint at Click Location</td></tr>
 <tr><td>Ctrl/⌘ + Z</td><td>Undo</td></tr>
 <tr><td>Ctrl/⌘ + Y</td><td>Redo</td></tr>
+<tr><td>Ctrl/⌘ + ,</td><td>Open Settings</td></tr>
 </table>
 
 ## UI Controls

--- a/lib/pages/home_page.dart
+++ b/lib/pages/home_page.dart
@@ -19,6 +19,7 @@ import 'package:pathplanner/util/prefs.dart';
 import 'package:pathplanner/widgets/custom_appbar.dart';
 import 'package:pathplanner/widgets/field_image.dart';
 import 'package:pathplanner/widgets/dialogs/settings_dialog.dart';
+import 'package:pathplanner/widgets/keyboard_shortcuts.dart';
 import 'package:pathplanner/widgets/pplib_update_card.dart';
 import 'package:pathplanner/widgets/update_card.dart';
 import 'package:shared_preferences/shared_preferences.dart';
@@ -229,7 +230,11 @@ class _HomePageState extends State<HomePage> with TickerProviderStateMixin {
       drawer: _projectDir == null ? null : _buildDrawer(context),
       body: ScaleTransition(
         scale: _scaleAnimation,
-        child: _buildBody(context),
+        child: KeyBoardShortcuts(
+          keysToPress: shortCut(BasicShortCuts.settings),
+          onKeysPressed: _showSettingsDialog,
+          child: _buildBody(context),
+        ),
       ),
     );
   }

--- a/lib/widgets/keyboard_shortcuts.dart
+++ b/lib/widgets/keyboard_shortcuts.dart
@@ -13,6 +13,7 @@ enum BasicShortCuts {
   save,
   undo,
   redo,
+  settings,
 }
 
 bool _isPressed(
@@ -139,5 +140,17 @@ Set<LogicalKeyboardKey> shortCut(BasicShortCuts basicShortCuts) {
       return {LogicalKeyboardKey.controlLeft, LogicalKeyboardKey.arrowRight};
     case BasicShortCuts.save:
       return {LogicalKeyboardKey.controlLeft, LogicalKeyboardKey.keyS};
+    case BasicShortCuts.settings:
+      if (Platform.isMacOS) {
+        return {
+          LogicalKeyboardKey.meta,
+          LogicalKeyboardKey.comma,
+        };
+      }
+
+      return {
+        LogicalKeyboardKey.control,
+        LogicalKeyboardKey.comma,
+      };
   }
 }

--- a/test/pages/home_page_test.dart
+++ b/test/pages/home_page_test.dart
@@ -2,6 +2,7 @@ import 'package:flutter/material.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:pathplanner/pages/home_page.dart';
 import 'package:pathplanner/widgets/custom_appbar.dart';
+import 'package:pathplanner/widgets/keyboard_shortcuts.dart';
 import 'package:shared_preferences/shared_preferences.dart';
 import 'package:file/memory.dart';
 import 'package:pathplanner/services/pplib_telemetry.dart';
@@ -37,8 +38,39 @@ void main() {
       ),
     ));
 
+    await tester.pumpAndSettle();
+
     expect(find.byType(HomePage), findsOneWidget);
     expect(find.byType(CustomAppBar), findsOneWidget);
     expect(find.text('PathPlanner'), findsOneWidget);
+  });
+
+  testWidgets('settings keyboard shortcut is wired correctly', (
+    WidgetTester tester,
+  ) async {
+    await tester.pumpWidget(MaterialApp(
+      home: HomePage(
+        appVersion: '1.0.0',
+        prefs: prefs,
+        onTeamColorChanged: (_) {},
+        fs: fs,
+        undoStack: undoStack,
+        telemetry: telemetry,
+        updateChecker: updateChecker,
+      ),
+    ));
+
+    await tester.pumpAndSettle();
+
+    // Verify KeyBoardShortcuts is in the widget tree with correct keys and callback
+    final shortcuts = find.byWidgetPredicate(
+      (widget) => widget is KeyBoardShortcuts,
+    );
+    expect(shortcuts, findsOneWidget);
+
+    // Verify the keysToPress matches settings shortcut
+    final shortcutWidget = tester.widget<KeyBoardShortcuts>(shortcuts);
+    expect(shortcutWidget.keysToPress, shortCut(BasicShortCuts.settings));
+    expect(shortcutWidget.onKeysPressed, isNotNull);
   });
 }

--- a/test/widgets/keyboard_shortcuts_test.dart
+++ b/test/widgets/keyboard_shortcuts_test.dart
@@ -1,0 +1,64 @@
+import 'dart:io';
+
+import 'package:flutter/services.dart';
+import 'package:flutter_test/flutter_test.dart';
+import 'package:pathplanner/widgets/keyboard_shortcuts.dart';
+
+void main() {
+  test('settings shortcut maps to Control+Comma on non-macOS', () {
+    if (Platform.isMacOS) {
+      return;
+    }
+
+    expect(
+      shortCut(BasicShortCuts.settings),
+      {LogicalKeyboardKey.control, LogicalKeyboardKey.comma},
+    );
+  });
+
+  test('settings shortcut maps to Meta+Comma on macOS', () {
+    if (!Platform.isMacOS) {
+      return;
+    }
+
+    expect(
+      shortCut(BasicShortCuts.settings),
+      {LogicalKeyboardKey.meta, LogicalKeyboardKey.comma},
+    );
+  });
+
+  test('settings shortcut requires a modifier, not a plain comma', () {
+    final keys = shortCut(BasicShortCuts.settings);
+
+    expect(keys, contains(LogicalKeyboardKey.comma));
+    expect(keys.length, 2);
+    expect(keys, isNot({LogicalKeyboardKey.comma}));
+  });
+
+  test('existing shortcuts remain unchanged', () {
+    if (Platform.isMacOS) {
+      expect(
+        shortCut(BasicShortCuts.undo),
+        {LogicalKeyboardKey.meta, LogicalKeyboardKey.keyZ},
+      );
+      expect(
+        shortCut(BasicShortCuts.redo),
+        {LogicalKeyboardKey.meta, LogicalKeyboardKey.keyY},
+      );
+    } else {
+      expect(
+        shortCut(BasicShortCuts.undo),
+        {LogicalKeyboardKey.control, LogicalKeyboardKey.keyZ},
+      );
+      expect(
+        shortCut(BasicShortCuts.redo),
+        {LogicalKeyboardKey.control, LogicalKeyboardKey.keyY},
+      );
+    }
+
+    expect(
+      shortCut(BasicShortCuts.save),
+      {LogicalKeyboardKey.controlLeft, LogicalKeyboardKey.keyS},
+    );
+  });
+}


### PR DESCRIPTION
### Overview

Fixes #871

Adds Ctrl+, on Windows/Linux and Cmd+, on macOS to open Settings. Also updates the keyboard shortcut documentation and adds regression coverage.

### Validation

* `flutter analyze`
* `flutter test` — 445/445 passed
* `dart format --output=none --set-exit-if-changed lib/* test/*`
* `git diff --check`
